### PR TITLE
feat: Change mount/unmount button icons to plus/minus

### DIFF
--- a/MountMate/Views/Main/MainView.swift
+++ b/MountMate/Views/Main/MainView.swift
@@ -275,7 +275,7 @@ struct VolumeRowView: View {
           }
         }) {
           Image(
-            systemName: volume.isMounted ? "xmark.circle.fill" : "arrow.up.circle.fill"
+            systemName: volume.isMounted ? "minus.circle.fill" : "plus.circle.fill"
           )
           .opacity(isLoading ? 0 : 1)
         }
@@ -300,7 +300,7 @@ struct VolumeRowView: View {
           Button {
             manager.unmount(volume: volume)
           } label: {
-            Label("Unmount", systemImage: "xmark.circle")
+            Label("Unmount", systemImage: "minus.circle")
           }
           Button {
             if let path = volume.mountPoint {
@@ -338,7 +338,7 @@ struct VolumeRowView: View {
           Button {
             manager.mount(volume: volume)
           } label: {
-            Label("Mount", systemImage: "arrow.up.circle")
+            Label("Mount", systemImage: "plus.circle")
           }
           Divider()
         }
@@ -464,7 +464,7 @@ struct NetworkShareMainRow: View {
           }
         }) {
           Image(
-            systemName: isMounted ? "xmark.circle.fill" : "arrow.up.circle.fill"
+            systemName: isMounted ? "minus.circle.fill" : "plus.circle.fill"
           )
           .opacity(isWorking ? 0 : 1)
         }


### PR DESCRIPTION
This changes the mount/unmount icons from up-arrow/cross to plus/minus (`plus.circle.fill` and `minus.circle.fill`).

Updated in three locations:
- Volume row mount button
- Volume context menu mount option
- Network share mount button

Motivation: after a month of using mountmate, I couldn't remember what the up-arrow button does. I initially was only going to replace the up-arrow with a plus, but then I decided it doesn't go well with the cross symbol (one is a rotation of the other). Plus and minus also just makes more sense.

Fixes #36

------------

Screenshot of the new behavior:

![SCR-20260116-ouwb](https://github.com/user-attachments/assets/572ba946-9a41-4bed-a2f2-645928159571)

I think it's pretty clear what each button does, even if you don't read the small text.

Relevant symbols:

<img width="506" height="128" alt="image" src="https://github.com/user-attachments/assets/310c64bd-ce05-40ec-a766-59ea381a5b52" />


Previously, the bottom ones were used (in swapped order)
