### PR TITLE
POC/FR: Change main menu icon while the app is unmounting a drive

### DIFF
--- a/MountMate/App/MountMateApp.swift
+++ b/MountMate/App/MountMateApp.swift
@@ -3,6 +3,40 @@
 import Sparkle
 import SwiftUI
 
+// MARK: - Dynamic Menu Bar Icon
+
+struct MenuBarIconView: View {
+  @ObservedObject var driveManager: DriveManager
+
+  /// Determines the appropriate icon based on current state
+  var currentIcon: String {
+    // Priority 1: Show busy state during operations
+    if driveManager.isUnmountingAll
+        || driveManager.busyVolumeIdentifier != nil
+        || driveManager.busyEjectingIdentifier != nil {
+      return "externaldrive.fill.badge.timemachine"
+    }
+
+    // Priority 2: Show error state if there's an error
+    if driveManager.userActionError != nil {
+      return "externaldrive.fill.trianglebadge.exclamationmark"
+    }
+
+    // Default: normal icon
+    return "externaldrive.fill"
+  }
+
+  var body: some View {
+    let icon = currentIcon
+    #if DEBUG
+    let _ = print("MenuBarIcon: \(icon)")
+    #endif
+    return Image(systemName: icon)
+  }
+}
+
+// MARK: - App Entry Point
+
 @main
 struct MountMateApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -19,11 +53,13 @@ struct MountMateApp: App {
   }
 
   var body: some Scene {
-    MenuBarExtra("MountMate", systemImage: "externaldrive.fill") {
+    MenuBarExtra {
       PopoverContent {
         MainView()
       }
       .environmentObject(driveManager)
+    } label: {
+      MenuBarIconView(driveManager: driveManager)
     }
     .menuBarExtraStyle(.window)
 


### PR DESCRIPTION
This is a proof of concept for making it so that when the app is mounting/unmounting a drive, the main menu icon changes to `externaldrive.fill.badge.timemachine`, and on error it sets `externaldrive.fill.trianglebadge.exclamationmark`.

In picture form:

<img width="500" height="120" alt="menu-bar-icons" src="https://github.com/user-attachments/assets/d58f5a05-410e-4446-9302-74c02388c103" />


I really like this functionality :). It means I can hit "unmount drive", close the MountMate window, and physically unplog the drive when I see the icon in my menu change back to normal.

I'm not sure if this code should be merged or is more of a POC/FR. I don't do much macOS programming myself, and this is written by AI. It seems to make sense, I've been using it myself, and it's been working fine so far, but I have no idea if it works well on other macOS versions (I'm on Sonoma), and the "error" state is barely tested. (**Update:** Though, on my computer, the error state works fine, at least in the case where a directory is still in use on the drive that's meant to be unmounted. Mountmate reports "Unknown error" in this case, but that seems to be independent of this patch)

I think this mostly supercedes #31.