### PR TITLE
Add fstab-backed custom mount point support for volumes

### DIFF
--- a/MountMate.xcodeproj/project.pbxproj
+++ b/MountMate.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 				"zh-Hant",
 				uk,
 				ru,
+				fr,
 			);
 			mainGroup = B4AADB082DFE3BBC00EDAAC2;
 			minimizedProjectReferenceProxies = 1;

--- a/MountMate/App/MountMateApp.swift
+++ b/MountMate/App/MountMateApp.swift
@@ -71,16 +71,6 @@ struct MountMateApp: App {
   }
 
   var body: some Scene {
-    MenuBarExtra {
-      PopoverContent {
-        MainView()
-      }
-      .environmentObject(driveManager)
-    } label: {
-      MenuBarIconView(driveManager: driveManager)
-    }
-    .menuBarExtraStyle(.window)
-
     Settings {
       SettingsView()
         .environmentObject(launchManager)

--- a/MountMate/Managers/DriveManager.swift
+++ b/MountMate/Managers/DriveManager.swift
@@ -305,6 +305,81 @@ class DriveManager: ObservableObject {
     }
   }
 
+  func remount(volume: Volume) {
+    DispatchQueue.main.async { self.busyVolumeIdentifier = volume.id }
+    DispatchQueue.global(qos: .userInitiated).async {
+      let result = runShell("diskutil unmount \(volume.deviceIdentifier.shellQuoted)")
+      DispatchQueue.main.async {
+        if let error = result.error, !error.isEmpty {
+          self.handleDiskUtilError(
+            error, for: volume.name, volume: volume, operation: .unmount)
+          self.busyVolumeIdentifier = nil
+          self.refreshDrives(qos: .userInitiated)
+          return
+        }
+
+        self.busyVolumeIdentifier = nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+          self.mount(volume: volume)
+        }
+      }
+    }
+  }
+
+  func normalizedMountPointPath(_ rawPath: String) -> String {
+    (rawPath.trimmingCharacters(in: .whitespacesAndNewlines) as NSString).expandingTildeInPath
+  }
+
+  func customMountPointValidationError(for rawPath: String, excluding volume: Volume? = nil)
+    -> String?
+  {
+    let path = normalizedMountPointPath(rawPath)
+
+    guard !path.isEmpty else {
+      return NSLocalizedString(
+        "Custom Mount Point Empty Path",
+        comment: "Custom mount point validation")
+    }
+    guard path.hasPrefix("/") else {
+      return NSLocalizedString(
+        "Custom Mount Point Must Be Absolute",
+        comment: "Custom mount point validation")
+    }
+    guard path != "/" else {
+      return NSLocalizedString(
+        "Custom Mount Point Cannot Be Root",
+        comment: "Custom mount point validation")
+    }
+    if let mountedVolumeName = mountedVolumeName(at: path, excluding: volume) {
+      return String(
+        format: NSLocalizedString(
+          "Custom Mount Point In Use",
+          comment: "Custom mount point validation"), mountedVolumeName)
+    }
+
+    var isDirectory = ObjCBool(false)
+    if FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue
+    {
+      return NSLocalizedString(
+        "Custom Mount Point Must Be Folder",
+        comment: "Custom mount point validation")
+    }
+
+    return nil
+  }
+
+  func inspectDirectory(at rawPath: String) throws -> (exists: Bool, isDirectory: Bool, isEmpty: Bool)
+  {
+    let path = normalizedMountPointPath(rawPath)
+    var isDirectory = ObjCBool(false)
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    guard exists else { return (false, false, true) }
+    guard isDirectory.boolValue else { return (true, false, false) }
+
+    let contents = try FileManager.default.contentsOfDirectory(atPath: path)
+    return (true, true, contents.isEmpty)
+  }
+
   // MARK: - Parsing and Data Creation Helpers
 
   private func parseDisks(from plist: [String: Any]) -> [PhysicalDisk] {
@@ -780,5 +855,33 @@ class DriveManager: ObservableObject {
       }
       self?.refreshDrives()
     }
+  }
+
+  private func mountedVolumeName(at rawPath: String, excluding volume: Volume? = nil) -> String? {
+    let targetPath = URL(fileURLWithPath: normalizedMountPointPath(rawPath)).standardizedFileURL.path
+    let keys: Set<URLResourceKey> = [.volumeNameKey, .volumeUUIDStringKey]
+    let mountedURLs =
+      FileManager.default.mountedVolumeURLs(
+        includingResourceValuesForKeys: Array(keys), options: []) ?? []
+
+    for url in mountedURLs {
+      guard url.standardizedFileURL.path == targetPath else { continue }
+
+      if let volume,
+        let currentMountPoint = volume.mountPoint,
+        URL(fileURLWithPath: currentMountPoint).standardizedFileURL.path == targetPath
+      {
+        continue
+      }
+
+      let values = try? url.resourceValues(forKeys: keys)
+      if let volume, values?.volumeUUIDString == volume.id {
+        continue
+      }
+
+      return values?.volumeName ?? url.lastPathComponent
+    }
+
+    return nil
   }
 }

--- a/MountMate/Managers/DriveManager.swift
+++ b/MountMate/Managers/DriveManager.swift
@@ -308,9 +308,16 @@ class DriveManager: ObservableObject {
   func remount(volume: Volume) {
     DispatchQueue.main.async { self.busyVolumeIdentifier = volume.id }
     DispatchQueue.global(qos: .userInitiated).async {
-      let result = runShell("diskutil unmount \(volume.deviceIdentifier.shellQuoted)")
+      let result = runProcess(
+        executable: "/usr/sbin/diskutil",
+        arguments: ["unmount", volume.deviceIdentifier])
       DispatchQueue.main.async {
-        if let error = result.error, !error.isEmpty {
+        if !result.succeeded {
+          let error = result.timedOut
+            ? "The operation timed out after 15 seconds."
+            : (result.stderr.isEmpty
+              ? "diskutil exited with code \(result.exitCode ?? -1)."
+              : result.stderr)
           self.handleDiskUtilError(
             error, for: volume.name, volume: volume, operation: .unmount)
           self.busyVolumeIdentifier = nil

--- a/MountMate/Managers/PersistenceManager.swift
+++ b/MountMate/Managers/PersistenceManager.swift
@@ -297,8 +297,10 @@ class PersistenceManager: ObservableObject {
 
   private func diskInfo(for deviceIdentifier: String) -> [String: Any]? {
     guard !deviceIdentifier.isEmpty else { return nil }
-    let output = runShell("diskutil info -plist \(deviceIdentifier.shellQuoted)").output
-    guard let data = output?.data(using: .utf8) else { return nil }
+    let result = runProcess(
+      executable: "/usr/sbin/diskutil",
+      arguments: ["info", "-plist", deviceIdentifier])
+    guard result.succeeded, let data = result.stdout.data(using: .utf8) else { return nil }
     return try? PropertyListSerialization.propertyList(from: data, options: [], format: nil)
       as? [String: Any]
   }
@@ -364,7 +366,7 @@ class PersistenceManager: ObservableObject {
     var index = 0
 
     while index < lines.count {
-      if lines[index] == comment {
+      if lines[index].trimmingCharacters(in: .whitespaces) == comment {
         index += 1
         if index < lines.count {
           index += 1
@@ -401,8 +403,16 @@ class PersistenceManager: ObservableObject {
     }
 
     let script = "do shell script \(command.appleScriptStringLiteral) with administrator privileges"
-    let result = runShell("/usr/bin/osascript -e \(script.shellQuoted)")
-    if let error = result.error, !error.isEmpty {
+    let result = runProcess(
+      executable: "/usr/bin/osascript",
+      arguments: ["-e", script],
+      timeout: 300)
+    if !result.succeeded {
+      let error = result.stderr.isEmpty
+        ? NSLocalizedString(
+          "Custom Mount Point System Error",
+          comment: "Fallback custom mount point system configuration error")
+        : result.stderr
       throw NSError(
         domain: "MountMate",
         code: 2,
@@ -417,7 +427,10 @@ class PersistenceManager: ObservableObject {
   private func isConflictingFstabEntry(_ line: String, volumeUUID: String) -> Bool {
     let trimmed = line.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return false }
-    return trimmed.hasPrefix("UUID=\(volumeUUID) ")
+    let uuidPrefix = "UUID=\(volumeUUID)"
+    guard trimmed.hasPrefix(uuidPrefix), trimmed.count > uuidPrefix.count else { return false }
+    let separatorIndex = trimmed.index(trimmed.startIndex, offsetBy: uuidPrefix.count)
+    return trimmed[separatorIndex].isWhitespace
   }
 
   private func fstabEscapedField(_ value: String) -> String {

--- a/MountMate/Managers/PersistenceManager.swift
+++ b/MountMate/Managers/PersistenceManager.swift
@@ -10,17 +10,21 @@ class PersistenceManager: ObservableObject {
   private let ignoredVolumesKey = "mountmate_ignoredVolumes_v4"
   private let blockedVolumesKey = "mountmate_blockedVolumes_v1"
   private let networkSharesKey = "mountmate_networkShares_v1"
+  private let customMountPointsKey = "mountmate_customMountPoints_v1"
 
   @Published var protectedVolumes: [ManagedVolumeInfo]
   @Published var ignoredVolumes: [ManagedVolumeInfo]
   @Published var blockedVolumes: [ManagedVolumeInfo]
   @Published var networkShares: [NetworkShare]
+  @Published var customMountPoints: [VolumeCustomMountPoint]
+  private let mountMateFstabPrefix = "# MountMate custom mount:"
 
   private init() {
     self.protectedVolumes = Self.load(from: protectedVolumesKey)
     self.ignoredVolumes = Self.load(from: ignoredVolumesKey)
     self.blockedVolumes = Self.load(from: blockedVolumesKey)
     self.networkShares = Self.load(from: networkSharesKey)
+    self.customMountPoints = Self.load(from: customMountPointsKey)
   }
 
   // MARK: - Actions
@@ -106,6 +110,144 @@ class PersistenceManager: ObservableObject {
     saveNetworkShares()
   }
 
+  func customMountPoint(for volume: Volume) -> VolumeCustomMountPoint? {
+    customMountPoints.first { $0.id == stableIdentifier(for: volume) }
+  }
+
+  func applyCustomMountPoint(_ mountPoint: String, selectedURL: URL?, for volume: Volume) -> String?
+  {
+    guard let volumeUUID = volumeUUIDForSystemMount(for: volume) else {
+      return NSLocalizedString(
+        "Custom Mount Point Requires UUID",
+        comment: "Custom mount point system configuration error")
+    }
+    guard let fileSystemType = resolvedFstabFileSystemType(for: volume) else {
+      return NSLocalizedString(
+        "Custom Mount Point Unsupported File System",
+        comment: "Custom mount point system configuration error")
+    }
+
+    do {
+      let currentContents = try loadSystemFstabContents()
+      let updatedContents = try updatedFstabContents(
+        from: currentContents,
+        for: volume,
+        volumeUUID: volumeUUID,
+        mountPoint: mountPoint,
+        fileSystemType: fileSystemType
+      )
+
+      if updatedContents != currentContents {
+        try installSystemFstabContents(updatedContents)
+      }
+
+      if let selectedURL, selectedURL.path == mountPoint {
+        saveCustomMountPoint(url: selectedURL, for: volume)
+      } else {
+        saveCustomMountPoint(mountPoint, for: volume)
+      }
+      return nil
+    } catch {
+      return String(
+        format: NSLocalizedString(
+          "Custom Mount Point System Save Error",
+          comment: "Custom mount point system configuration error"),
+        error.localizedDescription)
+    }
+  }
+
+  func saveCustomMountPoint(_ mountPoint: String, for volume: Volume) {
+    saveCustomMountPoint(mountPoint, bookmarkData: nil, for: volume)
+  }
+
+  func saveCustomMountPoint(url: URL, for volume: Volume) {
+    let bookmarkData = try? url.bookmarkData(
+      options: [.withSecurityScope],
+      includingResourceValuesForKeys: nil,
+      relativeTo: nil
+    )
+    saveCustomMountPoint(url.path, bookmarkData: bookmarkData, for: volume)
+  }
+
+  func resolveCustomMountPointURL(for volume: Volume) -> URL? {
+    guard let info = customMountPoint(for: volume) else { return nil }
+    guard let bookmarkData = info.bookmarkData else {
+      return URL(fileURLWithPath: info.mountPoint)
+    }
+
+    var isStale = false
+    if let resolvedURL = try? URL(
+      resolvingBookmarkData: bookmarkData,
+      options: [.withSecurityScope],
+      relativeTo: nil,
+      bookmarkDataIsStale: &isStale
+    ) {
+      if isStale {
+        saveCustomMountPoint(url: resolvedURL, for: volume)
+      }
+      return resolvedURL
+    }
+
+    return URL(fileURLWithPath: info.mountPoint)
+  }
+
+  @discardableResult
+  func withAccessToCustomMountPoint<T>(for volume: Volume, _ body: (URL) throws -> T) rethrows -> T? {
+    guard let url = resolveCustomMountPointURL(for: volume) else { return nil }
+    let scoped = url.startAccessingSecurityScopedResource()
+    defer {
+      if scoped {
+        url.stopAccessingSecurityScopedResource()
+      }
+    }
+    return try body(url)
+  }
+
+  private func saveCustomMountPoint(
+    _ mountPoint: String, bookmarkData: Data?, for volume: Volume
+  ) {
+    let identifier = stableIdentifier(for: volume)
+    let info = VolumeCustomMountPoint(
+      volumeUUID: volume.id,
+      backingDiskIdentifier: backingDiskIdentifier(for: volume),
+      name: volume.name,
+      mountPoint: mountPoint,
+      bookmarkData: bookmarkData
+    )
+
+    if let index = customMountPoints.firstIndex(where: { $0.id == identifier }) {
+      customMountPoints[index] = info
+    } else {
+      customMountPoints.append(info)
+    }
+    saveCustomMountPoints()
+  }
+
+  func clearCustomMountPoint(for volume: Volume) {
+    customMountPoints.removeAll { $0.id == stableIdentifier(for: volume) }
+    saveCustomMountPoints()
+  }
+
+  func removeCustomMountPoint(for volume: Volume) -> String? {
+    do {
+      let currentContents = try loadSystemFstabContents()
+      let updatedContents = removingManagedFstabEntry(from: currentContents, for: volume)
+
+      if updatedContents != currentContents {
+        try installSystemFstabContents(updatedContents)
+      }
+
+      clearCustomMountPoint(for: volume)
+      return nil
+    } catch {
+      return String(
+        format: NSLocalizedString(
+          "Custom Mount Point System Save Error",
+          comment: "Custom mount point system configuration error"),
+        error.localizedDescription)
+    }
+  }
+
   // MARK: - Helper Checkers
 
   func isVolumeProtected(_ volume: Volume) -> Bool {
@@ -121,6 +263,179 @@ class PersistenceManager: ObservableObject {
   func isVolumeBlocked(_ volume: Volume) -> Bool {
     guard let compositeId = volume.compositeId else { return false }
     return blockedVolumes.contains { $0.id == compositeId }
+  }
+
+  private func stableIdentifier(for volume: Volume) -> String {
+    "\(backingDiskIdentifier(for: volume))-\(volume.id)"
+  }
+
+  private func backingDiskIdentifier(for volume: Volume) -> String {
+    volume.diskUUID ?? volume.deviceIdentifier
+  }
+
+  private func volumeUUIDForSystemMount(for volume: Volume) -> String? {
+    volume.id == volume.deviceIdentifier ? nil : volume.id
+  }
+
+  private func resolvedFstabFileSystemType(for volume: Volume) -> String? {
+    let plist = diskInfo(for: volume.deviceIdentifier)
+    let candidates = [
+      plist?["FilesystemType"] as? String,
+      plist?["FilesystemName"] as? String,
+      plist?["Content"] as? String,
+      volume.fileSystemType,
+    ].compactMap { $0 }
+
+    for candidate in candidates {
+      if let mapped = mapFstabFileSystemType(candidate) {
+        return mapped
+      }
+    }
+
+    return nil
+  }
+
+  private func diskInfo(for deviceIdentifier: String) -> [String: Any]? {
+    guard !deviceIdentifier.isEmpty else { return nil }
+    let output = runShell("diskutil info -plist \(deviceIdentifier.shellQuoted)").output
+    guard let data = output?.data(using: .utf8) else { return nil }
+    return try? PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+      as? [String: Any]
+  }
+
+  private func mapFstabFileSystemType(_ rawValue: String) -> String? {
+    let value = rawValue.lowercased()
+    if value.contains("apfs") { return "apfs" }
+    if value.contains("hfs") { return "hfs" }
+    if value.contains("exfat") { return "exfat" }
+    if value.contains("msdos") || value.contains("dos_fat") || value.contains("fat32")
+      || value.contains("fat")
+    {
+      return "msdos"
+    }
+    if value.contains("ntfs") { return "ntfs" }
+
+    let normalized = value.filter { $0.isLetter || $0.isNumber }
+    return normalized.isEmpty ? nil : normalized
+  }
+
+  private func loadSystemFstabContents() throws -> String {
+    let path = "/etc/fstab"
+    guard FileManager.default.fileExists(atPath: path) else { return "" }
+    return try String(contentsOfFile: path, encoding: .utf8)
+  }
+
+  private func updatedFstabContents(
+    from contents: String,
+    for volume: Volume,
+    volumeUUID: String,
+    mountPoint: String,
+    fileSystemType: String
+  ) throws -> String {
+    let withoutManagedEntry = removingManagedFstabEntry(from: contents, for: volume)
+    let activeLines = withoutManagedEntry.components(separatedBy: .newlines)
+
+    if activeLines.contains(where: { isConflictingFstabEntry($0, volumeUUID: volumeUUID) }) {
+      throw NSError(
+        domain: "MountMate",
+        code: 1,
+        userInfo: [
+          NSLocalizedDescriptionKey: NSLocalizedString(
+            "Custom Mount Point System Conflict",
+            comment: "Custom mount point system configuration error")
+        ])
+    }
+
+    var normalized = trimmedFstabContents(withoutManagedEntry)
+    if !normalized.isEmpty {
+      normalized += "\n"
+    }
+
+    let entryLine =
+      "UUID=\(volumeUUID) \(fstabEscapedField(mountPoint)) \(fileSystemType) rw"
+    normalized += "\(managedFstabComment(for: volume))\n\(entryLine)\n"
+    return normalized
+  }
+
+  private func removingManagedFstabEntry(from contents: String, for volume: Volume) -> String {
+    let comment = managedFstabComment(for: volume)
+    let lines = contents.components(separatedBy: .newlines)
+    var filtered: [String] = []
+    var index = 0
+
+    while index < lines.count {
+      if lines[index] == comment {
+        index += 1
+        if index < lines.count {
+          index += 1
+        }
+        continue
+      }
+      filtered.append(lines[index])
+      index += 1
+    }
+
+    return trimmedFstabContents(filtered.joined(separator: "\n"))
+  }
+
+  private func installSystemFstabContents(_ contents: String) throws {
+    let normalizedContents = trimmedFstabContents(contents)
+    let fileManager = FileManager.default
+    let temporaryURL = fileManager.temporaryDirectory
+      .appendingPathComponent("mountmate-fstab-\(UUID().uuidString)")
+
+    if !normalizedContents.isEmpty {
+      try normalizedContents.write(to: temporaryURL, atomically: true, encoding: .utf8)
+    }
+
+    defer {
+      try? fileManager.removeItem(at: temporaryURL)
+    }
+
+    let command: String
+    if normalizedContents.isEmpty {
+      command = "/bin/rm -f /etc/fstab"
+    } else {
+      command =
+        "/usr/bin/install -m 644 -o root -g wheel \(temporaryURL.path.shellQuoted) /etc/fstab"
+    }
+
+    let script = "do shell script \(command.appleScriptStringLiteral) with administrator privileges"
+    let result = runShell("/usr/bin/osascript -e \(script.shellQuoted)")
+    if let error = result.error, !error.isEmpty {
+      throw NSError(
+        domain: "MountMate",
+        code: 2,
+        userInfo: [NSLocalizedDescriptionKey: error])
+    }
+  }
+
+  private func managedFstabComment(for volume: Volume) -> String {
+    "\(mountMateFstabPrefix) \(stableIdentifier(for: volume))"
+  }
+
+  private func isConflictingFstabEntry(_ line: String, volumeUUID: String) -> Bool {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return false }
+    return trimmed.hasPrefix("UUID=\(volumeUUID) ")
+  }
+
+  private func fstabEscapedField(_ value: String) -> String {
+    value
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: " ", with: "\\040")
+      .replacingOccurrences(of: "\t", with: "\\011")
+  }
+
+  private func trimmedFstabContents(_ contents: String) -> String {
+    let lines = contents.components(separatedBy: .newlines)
+    var end = lines.count
+    while end > 0 && lines[end - 1].trimmingCharacters(in: .whitespaces).isEmpty {
+      end -= 1
+    }
+
+    guard end > 0 else { return "" }
+    return lines[..<end].joined(separator: "\n") + "\n"
   }
 
   // MARK: - Private Save/Load Helpers
@@ -143,5 +458,6 @@ class PersistenceManager: ObservableObject {
   private func saveIgnoredVolumes() { save(ignoredVolumes, to: ignoredVolumesKey) }
   private func saveBlockedVolumes() { save(blockedVolumes, to: blockedVolumesKey) }
   private func saveNetworkShares() { save(networkShares, to: networkSharesKey) }
+  private func saveCustomMountPoints() { save(customMountPoints, to: customMountPointsKey) }
 
 }

--- a/MountMate/Models/ManagedVolumeInfo.swift
+++ b/MountMate/Models/ManagedVolumeInfo.swift
@@ -11,3 +11,15 @@ struct ManagedVolumeInfo: Codable, Hashable, Identifiable {
     "\(diskUUID)-\(volumeUUID)"
   }
 }
+
+struct VolumeCustomMountPoint: Codable, Hashable, Identifiable {
+  let volumeUUID: String
+  let backingDiskIdentifier: String
+  let name: String
+  var mountPoint: String
+  var bookmarkData: Data?
+
+  var id: String {
+    "\(backingDiskIdentifier)-\(volumeUUID)"
+  }
+}

--- a/MountMate/Resources/AppIcon.icon/icon.json
+++ b/MountMate/Resources/AppIcon.icon/icon.json
@@ -1,22 +1,25 @@
 {
   "fill-specializations" : [
     {
-      "value" : {
-        "solid" : "extended-gray:1.00000,1.00000"
-      }
+      "value" : "system-light"
     },
     {
       "appearance" : "dark",
-      "value" : {
-        "solid" : "extended-gray:0.00000,1.00000"
-      }
+      "value" : "system-dark"
     }
   ],
   "groups" : [
     {
-      "blur-material" : null,
+      "blend-mode-specializations" : [
+        {
+          "appearance" : "dark",
+          "value" : "hard-light"
+        }
+      ],
+      "blur-material" : 0.5,
       "layers" : [
         {
+          "blend-mode" : "normal",
           "fill-specializations" : [
             {
               "value" : {
@@ -56,28 +59,20 @@
               }
             },
             {
+              "appearance" : "dark",
+              "value" : "none"
+            },
+            {
               "appearance" : "tinted",
               "value" : {
-                "linear-gradient" : [
-                  "extended-gray:0.25000,1.00000",
-                  "extended-gray:0.00000,1.00000"
-                ],
-                "orientation" : {
-                  "start" : {
-                    "x" : 0.5,
-                    "y" : 1
-                  },
-                  "stop" : {
-                    "x" : 0.5,
-                    "y" : 0.3
-                  }
-                }
+                "automatic-gradient" : "extended-gray:0.00000,1.00000"
               }
             }
           ],
-          "glass" : false,
+          "glass" : true,
           "image-name" : "on-off.svg",
           "name" : "on-off",
+          "opacity" : 1,
           "position" : {
             "scale" : 0.4,
             "translation-in-points" : [
@@ -89,63 +84,23 @@
         {
           "fill-specializations" : [
             {
-              "value" : {
-                "linear-gradient" : [
-                  "extended-gray:0.25000,1.00000",
-                  "extended-gray:0.00000,1.00000"
-                ],
-                "orientation" : {
-                  "start" : {
-                    "x" : 0.5,
-                    "y" : 0
-                  },
-                  "stop" : {
-                    "x" : 0.5,
-                    "y" : 0.7
-                  }
-                }
-              }
+              "value" : "automatic"
             },
             {
               "appearance" : "dark",
               "value" : {
-                "linear-gradient" : [
-                  "extended-gray:0.75000,1.00000",
-                  "extended-gray:1.00000,1.00000"
-                ],
-                "orientation" : {
-                  "start" : {
-                    "x" : 0.5,
-                    "y" : 0
-                  },
-                  "stop" : {
-                    "x" : 0.5,
-                    "y" : 0.7
-                  }
-                }
+                "solid" : "display-p3:0.93671,0.93671,0.93671,1.00000"
               }
             },
             {
               "appearance" : "tinted",
               "value" : {
-                "linear-gradient" : [
-                  "extended-gray:0.75000,1.00000",
-                  "extended-gray:1.00000,1.00000"
-                ],
-                "orientation" : {
-                  "start" : {
-                    "x" : 0.5,
-                    "y" : 0
-                  },
-                  "stop" : {
-                    "x" : 0.5,
-                    "y" : 0.7
-                  }
-                }
+                "automatic-gradient" : "extended-gray:1.00000,0.70323"
               }
             }
           ],
-          "glass" : false,
+          "glass" : true,
+          "hidden" : false,
           "image-name" : "hard-disk.svg",
           "name" : "hard-disk",
           "position" : {
@@ -157,8 +112,9 @@
           }
         }
       ],
+      "lighting" : "individual",
       "shadow" : {
-        "kind" : "neutral",
+        "kind" : "layer-color",
         "opacity" : 0.5
       },
       "specular" : false,

--- a/MountMate/Resources/en.lproj/Localizable.strings
+++ b/MountMate/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings (English)
 */
 
@@ -148,6 +148,10 @@
 "Options" = "Options";
 "Leave empty to use default location" = "Leave empty to use default location";
 "Preview: %@" = "Preview: %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
 "Custom Mount Point Menu" = "Custom Mount Point…";
 "Use Custom Mount Point" = "Use custom mount point";
 "Folder Path" = "Folder Path";
@@ -159,7 +163,6 @@
 "Save" = "Save";
 "Create" = "Create";
 "Use Folder" = "Use Folder";
-"Custom Mount Point Help" = "Leave this off to use the standard macOS mount location.";
 "Custom Mount Point Empty Means Default" = "Leave this empty to use the standard macOS mount location.";
 "Custom Mount Point System Helper" = "Leave this empty to use the standard macOS mount location. Saving updates the system mount rule and may ask for your admin password once.";
 "Custom Mount Point Summary" = "Custom: %@";
@@ -187,3 +190,51 @@
 "The disk is in use. Do you want to force eject it?" = "The disk is in use. Do you want to force eject it?";
 "This may result in data loss." = "This may result in data loss.";
 "Remember password in Keychain" = "Remember password in Keychain";
+
+// Additional strings discovered in SwiftUI views
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Unmount All Volumes";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - Mount All Volumes";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility.";
+
+"Volume: %@" = "Volume: %@";
+"Disk: %@" = "Disk: %@";
+"APFS Container • %@" = "APFS Container • %@";
+
+"Settings" = "Settings";
+"Refresh Drives" = "Refresh Drives";
+"Retry" = "Retry";
+"Auto-mounts at login" = "Auto-mounts at login";
+"Mount Now" = "Mount Now";
+"Edit" = "Edit";
+"Delete" = "Delete";
+
+"Accessibility Permission Required" = "Accessibility Permission Required";
+
+"Add Share" = "Add Share";
+
+"Optional (Defaults to share name)" = "Optional (Defaults to share name)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Optional (Guest)";
+
+// Missing keys discovered: Settings labels
+"Enable Keyboard Shortcuts" = "Enable Keyboard Shortcuts";
+"About & Updates" = "About & Updates";
+
+// Remaining UI strings
+"MountMate" = "MountMate";
+"Expand All" = "Expand All";
+"Collapse All" = "Collapse All";
+"Try Again" = "Try Again";
+"Action Failed" = "Action Failed";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ used / %@ (%@ free)";

--- a/MountMate/Resources/en.lproj/Localizable.strings
+++ b/MountMate/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,38 @@
 "Options" = "Options";
 "Leave empty to use default location" = "Leave empty to use default location";
 "Preview: %@" = "Preview: %@";
+"Custom Mount Point Menu" = "Custom Mount Point…";
+"Use Custom Mount Point" = "Use custom mount point";
+"Folder Path" = "Folder Path";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "Choose…";
+"Choose" = "Choose";
+"Reset" = "Reset";
+"Default Path" = "Default Path";
+"Save" = "Save";
+"Create" = "Create";
+"Use Folder" = "Use Folder";
+"Custom Mount Point Help" = "Leave this off to use the standard macOS mount location.";
+"Custom Mount Point Empty Means Default" = "Leave this empty to use the standard macOS mount location.";
+"Custom Mount Point System Helper" = "Leave this empty to use the standard macOS mount location. Saving updates the system mount rule and may ask for your admin password once.";
+"Custom Mount Point Summary" = "Custom: %@";
+"Create Folder Title" = "Create Folder?";
+"Create Folder Message" = "This folder does not exist yet. MountMate can create it before saving.";
+"Folder Not Empty Title" = "Folder Not Empty";
+"Folder Not Empty Message" = "The selected folder already contains files. Mounting here may temporarily hide them while the volume is mounted.";
+"Custom Mount Point Empty Path" = "Enter a folder path.";
+"Custom Mount Point Must Be Absolute" = "The custom mount point must be an absolute path.";
+"Custom Mount Point Cannot Be Root" = "The custom mount point cannot be the root folder.";
+"Custom Mount Point In Use" = "The folder is already being used by the mounted volume “%@”.";
+"Custom Mount Point Must Be Folder" = "The custom mount point must be a folder.";
+"Custom Mount Point Prepare Fallback" = "MountMate could not prepare the custom mount point.";
+"Custom Mount Point Prepare Error" = "MountMate could not prepare the custom mount point.\n\nDetails:\n%@";
+"Custom Mount Point Inspect Error" = "MountMate could not inspect this folder.\n\nDetails:\n%@";
+"Custom Mount Point Create Error" = "MountMate could not create this folder.\n\nDetails:\n%@";
+"Custom Mount Point Requires UUID" = "This volume does not expose a stable UUID, so MountMate cannot add a system mount rule for it.";
+"Custom Mount Point Unsupported File System" = "MountMate could not determine the correct filesystem type for this volume's system mount rule.";
+"Custom Mount Point System Conflict" = "This volume already has a different /etc/fstab entry that is not managed by MountMate.";
+"Custom Mount Point System Save Error" = "MountMate could not update the system mount rule.\n\nDetails:\n%@";
 
 // MARK: - Force Eject
 //=============================================

--- a/MountMate/Resources/en.lproj/Localizable.strings
+++ b/MountMate/Resources/en.lproj/Localizable.strings
@@ -182,6 +182,7 @@
 "Custom Mount Point Requires UUID" = "This volume does not expose a stable UUID, so MountMate cannot add a system mount rule for it.";
 "Custom Mount Point Unsupported File System" = "MountMate could not determine the correct filesystem type for this volume's system mount rule.";
 "Custom Mount Point System Conflict" = "This volume already has a different /etc/fstab entry that is not managed by MountMate.";
+"Custom Mount Point System Error" = "MountMate could not update the system mount rule.";
 "Custom Mount Point System Save Error" = "MountMate could not update the system mount rule.\n\nDetails:\n%@";
 
 // MARK: - Force Eject
@@ -224,10 +225,6 @@
 "192.168.1.100" = "192.168.1.100";
 "public" = "public";
 "Optional (Guest)" = "Optional (Guest)";
-
-// Missing keys discovered: Settings labels
-"Enable Keyboard Shortcuts" = "Enable Keyboard Shortcuts";
-"About & Updates" = "About & Updates";
 
 // Remaining UI strings
 "MountMate" = "MountMate";

--- a/MountMate/Resources/fr.lproj/Localizable.strings
+++ b/MountMate/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,230 @@
+/*
+  Localizable.strings (Français)
+*/
+
+// MARK: - Main View & Sections
+//=============================================
+
+"No Drives Found" = "Aucun disque trouvé";
+"Connect a USB drive, SD card, or mount a disk image to see it here." = "Connectez un disque USB, une carte SD ou montez une image disque pour l'afficher ici.";
+"Internal Disks" = "Disques internes";
+"External Disks" = "Disques externes";
+"Disk Images" = "Images disque";
+"Snapshots" = "Instantanés";
+
+
+// MARK: - Action Buttons & Tooltips
+//=============================================
+
+"Unmount All" = "Tout démonter";
+"Eject" = "Éjecter";
+"Mount" = "Monter";
+"Unmount" = "Démonter";
+"Quit MountMate" = "Quitter MountMate";
+
+
+// MARK: - Volume & Disk Details
+//=============================================
+
+"Unknown" = "Inconnu";
+"Unmounted" = "Non monté";
+
+
+// MARK: - Context Menus
+//=============================================
+
+"Ignore This Disk" = "Ignorer ce disque";
+"Ignore This Volume" = "Ignorer ce volume";
+"Protect from 'Unmount All'" = "Protéger de « Tout démonter »";
+"Unprotect from 'Unmount All'" = "Ne plus protéger de « Tout démonter »";
+"Open in Finder" = "Ouvrir dans le Finder";
+
+
+// MARK: - Settings View
+//=============================================
+
+"MountMate Settings" = "Réglages de MountMate";
+
+// Tabs
+"General" = "Général";
+"Management" = "Gestion";
+
+// General Tab
+"Show Internal Disks" = "Afficher les disques internes";
+"Start MountMate at Login" = "Lancer MountMate à l'ouverture de session";
+"Block USB Auto-Mount" = "Bloquer le montage automatique des périphériques USB";
+"Unmount All Disks on Sleep" = "Démonter tous les disques à la mise en veille";
+"Language" = "Langue";
+"Enable Keyboard Shortcuts" = "Activer les raccourcis clavier";
+
+// About & Updates Section
+"Homepage" = "Page d'accueil";
+"Support Email" = "E-mail du support";
+"Donate" = "Faire un don";
+"Check for Updates..." = "Rechercher des mises à jour...";
+"About & Updates" = "À propos & Mises à jour";
+
+// Management Tab
+"Ignored Volumes" = "Volumes ignorés";
+"No Ignored Volumes" = "Aucun volume ignoré";
+"Right-click a volume to ignore it. Useful for system partitions like 'EFI' that you don't need to manage." = "Faites un clic droit sur un volume pour l'ignorer. Utile pour les partitions système comme « EFI » que vous n'avez pas besoin de gérer.";
+"Protected Volumes" = "Volumes protégés";
+"No Protected Volumes" = "Aucun volume protégé";
+"Right-click a volume to protect it from 'Unmount All' and sleep actions." = "Faites un clic droit sur un volume pour le protéger de « Tout démonter » et des actions liées à la mise en veille.";
+
+"Don't Auto-Mount This Volume" = "Ne pas monter automatiquement ce volume";
+"Blocked from Auto-Mounting" = "Montage automatique bloqué";
+"No Volumes Blocked from Auto-Mounting" = "Aucun volume avec montage automatique bloqué";
+"Right-click a volume to prevent it from mounting automatically when connected." = "Faites un clic droit sur un volume pour empêcher son montage automatique lors de la connexion.";
+
+// MARK: - Alerts & Errors
+//=============================================
+
+// Titles
+"Could Not Load Disks" = "Impossible de charger les disques";
+"Data Parsing Error" = "Erreur d'analyse des données";
+"Eject Failed" = "Échec de l'éjection";
+"Mount Failed" = "Échec du montage";
+"Unmount Failed" = "Échec du démontage";
+"“%@” is locked" = "« %@ » est verrouillé";
+"Full Disk Access Recommended" = "Accès complet au disque recommandé";
+
+// Buttons
+"OK" = "OK";
+"Unlock" = "Déverrouiller";
+"Cancel" = "Annuler";
+"Open System Settings" = "Ouvrir les Réglages Système...";
+"Later" = "Plus tard";
+
+// Verbs for error messages
+"unmount" = "démonter";
+"eject" = "éjecter";
+"mount" = "monter";
+
+// Error Messages & Formats
+"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nVeuillez accorder à MountMate l'accès complet au disque dans Réglages Système > Confidentialité et sécurité.";
+"The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "La partition « EFI » ne peut pas être montée directement. Il s'agit d'une partition système spéciale, et ce comportement est normal.";
+"Failed to eject “%@” because one of its volumes is busy or in use." = "Impossible d'éjecter « %@ » car l'un de ses volumes est occupé ou en cours d'utilisation.";
+"Failed to %@ “%@” because it is currently in use by another application." = "Impossible de %@ « %@ » car il est actuellement utilisé par une autre application.";
+"Failed to %@ “%@” because it is currently in use by “%@”." = "Impossible de %@ « %@ » car il est actuellement utilisé par « %@ ».";
+"An unknown error occurred while trying to %@ “%@”." = "Une erreur inconnue s'est produite lors de la tentative de %@ « %@ ».";
+"Enter the password to unlock “%@”" = "Saisissez le mot de passe pour déverrouiller « %@ »";
+"Password" = "Mot de passe";
+"To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Pour permettre à MountMate de voir tous les types de disques et d'éviter les erreurs, veuillez accorder l'accès complet au disque.\n\nCliquez sur « Ouvrir les Réglages Système » pour accéder directement au bon panneau.";
+"MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate n'a pas pu récupérer les informations sur les disques. Le système est peut-être occupé, un disque ne répond peut-être pas ou les autorisations sont incorrectes.";
+
+// MARK: - App Lifecycle & Loading
+//=============================================
+
+"Loading Disks..." = "Chargement des disques...";
+"Restart Required" = "Redémarrage requis";
+"Please restart MountMate for the language change to take effect." = "Veuillez redémarrer MountMate pour que le changement de langue prenne effet.";
+"Restart Now" = "Redémarrer maintenant";
+
+// MARK: - Network Shares
+//=============================================
+"Network Shares" = "Partages réseau";
+"Add Network Share" = "Ajouter un partage réseau";
+"Edit Network Share" = "Modifier un partage réseau";
+"Server Address" = "Adresse du serveur";
+"Share Name/Path" = "Nom/chemin du partage";
+"Username" = "Nom d'utilisateur";
+"Password" = "Mot de passe";
+"Custom Mount Point" = "Point de montage personnalisé";
+"Mount at Login" = "Monter à l'ouverture de session";
+"MountMate can automatically mount these SMB shares at login." = "MountMate peut monter automatiquement ces partages SMB à l'ouverture de session.";
+"No Network Shares Configured" = "Aucun partage réseau configuré";
+"Mounted" = "Monté";
+"Not Mounted" = "Non monté";
+"Display Name" = "Nom d'affichage";
+"Connection" = "Connexion";
+"Credentials" = "Identifiants";
+"Options" = "Options";
+"Leave empty to use default location" = "Laissez vide pour utiliser l'emplacement par défaut";
+"Preview: %@" = "Aperçu : %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
+"Custom Mount Point Menu" = "Point de montage personnalisé…";
+"Use Custom Mount Point" = "Utiliser un point de montage personnalisé";
+"Folder Path" = "Chemin du dossier";
+"Custom Mount Point Path Prompt" = "/Volumes/MonDisque";
+"Choose Folder" = "Choisir un dossier…";
+"Choose" = "Choisir";
+"Reset" = "Réinitialiser";
+"Default Path" = "Chemin par défaut";
+"Save" = "Enregistrer";
+"Create" = "Créer";
+"Use Folder" = "Utiliser ce dossier";
+"Custom Mount Point Empty Means Default" = "Laissez vide pour utiliser l'emplacement par défaut.";
+"Custom Mount Point System Helper" = "Laissez vide pour utiliser l'emplacement par défaut. L'enregistrement mettra à jour les règles système et pourra demander votre mot de passe administrateur une fois.";
+"Custom Mount Point Summary" = "Personnalisé : %@";
+"Create Folder Title" = "Créer un dossier ?";
+"Create Folder Message" = "Ce dossier n'existe pas encore. MountMate peut le créer avant de l'enregistrer.";
+"Folder Not Empty Title" = "Dossier non vide";
+"Folder Not Empty Message" = "Le dossier sélectionné contient déjà des fichiers. Le montage à cet emplacement peut temporairement les masquer tant que le volume est monté.";
+"Custom Mount Point Empty Path" = "Saisissez un chemin de dossier.";
+"Custom Mount Point Must Be Absolute" = "Le point de montage personnalisé doit être un chemin absolu.";
+"Custom Mount Point Cannot Be Root" = "Le point de montage personnalisé ne peut pas être le dossier racine.";
+"Custom Mount Point In Use" = "Ce dossier est déjà utilisé par le volume monté « %@ ».";
+"Custom Mount Point Must Be Folder" = "Le point de montage personnalisé doit être un dossier.";
+"Custom Mount Point Prepare Fallback" = "MountMate n'a pas pu préparer le point de montage personnalisé.";
+"Custom Mount Point Prepare Error" = "MountMate n'a pas pu préparer le point de montage personnalisé.\n\nDétails :\n%@";
+"Custom Mount Point Inspect Error" = "MountMate n'a pas pu inspecter ce dossier.\n\nDétails :\n%@";
+"Custom Mount Point Create Error" = "MountMate n'a pas pu créer ce dossier.\n\nDétails :\n%@";
+"Custom Mount Point Requires UUID" = "Ce volume n'expose pas d'UUID stable, donc MountMate ne peut pas ajouter de règle de montage système pour celui-ci.";
+"Custom Mount Point Unsupported File System" = "MountMate n'a pas pu déterminer le type de système de fichiers correct pour la règle de montage système de ce volume.";
+"Custom Mount Point System Conflict" = "Ce volume possède déjà une entrée /etc/fstab différente qui n'est pas gérée par MountMate.";
+"Custom Mount Point System Save Error" = "MountMate n'a pas pu mettre à jour la règle de montage système.\n\nDétails :\n%@";
+
+// MARK: - Force Eject
+//=============================================
+"Force Eject" = "Forcer l'éjection";
+"The disk is in use. Do you want to force eject it?" = "Le disque est en cours d'utilisation. Voulez-vous forcer son éjection ?";
+"This may result in data loss." = "Cela peut entraîner une perte de données.";
+"Remember password in Keychain" = "Mémoriser le mot de passe dans le Trousseau";
+
+// Chaînes supplémentaires découvertes dans les vues SwiftUI
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Tout démonter";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - Tout monter";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Pour utiliser les raccourcis clavier, accordez à MountMate l'accès Accessibilité dans Réglages Système → Confidentialité & Sécurité → Accessibilité.";
+
+"Volume: %@" = "Volume : %@";
+"Disk: %@" = "Disque : %@";
+"APFS Container • %@" = "Conteneur APFS • %@";
+
+"Settings" = "Paramètres";
+"Refresh Drives" = "Actualiser les disques";
+"Retry" = "Réessayer";
+"Auto-mounts at login" = "Monte automatiquement à l'ouverture de session";
+"Mount Now" = "Monter maintenant";
+"Edit" = "Modifier";
+"Delete" = "Supprimer";
+
+"Accessibility Permission Required" = "Permission Accessibilité requise";
+
+"Add Share" = "Ajouter un partage";
+
+"Optional (Defaults to share name)" = "Optionnel (Par défaut : nom du partage)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Optionnel (Invité)";
+
+// Chaînes restantes
+"MountMate" = "MountMate";
+"Expand All" = "Tout développer";
+"Collapse All" = "Tout réduire";
+"Try Again" = "Réessayer";
+"Action Failed" = "Action échouée";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ utilisé / %@ (%@ libres)";

--- a/MountMate/Resources/fr.lproj/Localizable.strings
+++ b/MountMate/Resources/fr.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "Custom Mount Point Requires UUID" = "Ce volume n'expose pas d'UUID stable, donc MountMate ne peut pas ajouter de règle de montage système pour celui-ci.";
 "Custom Mount Point Unsupported File System" = "MountMate n'a pas pu déterminer le type de système de fichiers correct pour la règle de montage système de ce volume.";
 "Custom Mount Point System Conflict" = "Ce volume possède déjà une entrée /etc/fstab différente qui n'est pas gérée par MountMate.";
+"Custom Mount Point System Error" = "MountMate n'a pas pu mettre à jour la règle de montage système.";
 "Custom Mount Point System Save Error" = "MountMate n'a pas pu mettre à jour la règle de montage système.\n\nDétails :\n%@";
 
 // MARK: - Force Eject

--- a/MountMate/Resources/ru.lproj/Localizable.strings
+++ b/MountMate/Resources/ru.lproj/Localizable.strings
@@ -155,3 +155,4 @@
 "The disk is in use. Do you want to force eject it?" = "Диск используется. Желаете принудительно извлечь его?";
 "This may result in data loss." = "Это может привести к потере данных.";
 "Remember password in Keychain" = "Запомнить пароль в Keychain";
+"Custom Mount Point System Error" = "MountMate не удалось обновить системное правило монтирования.";

--- a/MountMate/Resources/uk.lproj/Localizable.strings
+++ b/MountMate/Resources/uk.lproj/Localizable.strings
@@ -148,6 +148,38 @@
 "Options" = "Параметри";
 "Leave empty to use default location" = "Залиште порожнім, щоб використовувати типове місце";
 "Preview: %@" = "Попередній перегляд: %@";
+"Custom Mount Point Menu" = "Власна точка монтування…";
+"Use Custom Mount Point" = "Використовувати власну точку монтування";
+"Folder Path" = "Шлях до теки";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "Вибрати…";
+"Choose" = "Вибрати";
+"Reset" = "Скинути";
+"Default Path" = "Типовий шлях";
+"Save" = "Зберегти";
+"Create" = "Створити";
+"Use Folder" = "Використати теку";
+"Custom Mount Point Help" = "Вимкніть це, щоб використовувати стандартне місце монтування macOS.";
+"Custom Mount Point Empty Means Default" = "Залиште поле порожнім, щоб використовувати стандартне місце монтування macOS.";
+"Custom Mount Point System Helper" = "Залиште поле порожнім, щоб використовувати стандартне місце монтування macOS. Збереження оновлює системне правило монтування і може один раз попросити пароль адміністратора.";
+"Custom Mount Point Summary" = "Власна: %@";
+"Create Folder Title" = "Створити теку?";
+"Create Folder Message" = "Ця тека ще не існує. MountMate може створити її перед збереженням.";
+"Folder Not Empty Title" = "Тека не порожня";
+"Folder Not Empty Message" = "Вибрана тека вже містить файли. Монтування тут може тимчасово приховати їх, поки том змонтований.";
+"Custom Mount Point Empty Path" = "Введіть шлях до теки.";
+"Custom Mount Point Must Be Absolute" = "Власна точка монтування повинна бути абсолютним шляхом.";
+"Custom Mount Point Cannot Be Root" = "Власна точка монтування не може бути кореневою текою.";
+"Custom Mount Point In Use" = "Ця тека вже використовується змонтованим томом «%@».";
+"Custom Mount Point Must Be Folder" = "Власна точка монтування повинна бути текою.";
+"Custom Mount Point Prepare Fallback" = "MountMate не зміг підготувати власну точку монтування.";
+"Custom Mount Point Prepare Error" = "MountMate не зміг підготувати власну точку монтування.\n\nДеталі:\n%@";
+"Custom Mount Point Inspect Error" = "MountMate не зміг перевірити цю теку.\n\nДеталі:\n%@";
+"Custom Mount Point Create Error" = "MountMate не зміг створити цю теку.\n\nДеталі:\n%@";
+"Custom Mount Point Requires UUID" = "Цей том не має стабільного UUID, тому MountMate не може додати для нього системне правило монтування.";
+"Custom Mount Point Unsupported File System" = "MountMate не зміг визначити правильний тип файлової системи для системного правила монтування цього тому.";
+"Custom Mount Point System Conflict" = "Для цього тому вже існує інший запис /etc/fstab, яким MountMate не керує.";
+"Custom Mount Point System Save Error" = "MountMate не зміг оновити системне правило монтування.\n\nДеталі:\n%@";
 
 // MARK: - Force Eject
 //=============================================

--- a/MountMate/Resources/uk.lproj/Localizable.strings
+++ b/MountMate/Resources/uk.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings (Ukrainian)
 */
 
@@ -61,6 +61,7 @@
 "Block USB Auto-Mount" = "Блокувати автопідключення USB";
 "Unmount All Disks on Sleep" = "Відмонтувати всі диски під час сну";
 "Language" = "Мова";
+"Enable Keyboard Shortcuts" = "Увімкнути комбінації клавіш";
 
 // About & Updates Section
 "About & Updates" = "Про програму та оновлення";
@@ -68,6 +69,7 @@
 "Support Email" = "Електронна пошта підтримки";
 "Donate" = "Пожертвувати";
 "Check for Updates..." = "Перевірити оновлення...";
+"About & Updates" = "Про програму та оновлення";
 
 // Management Tab
 "Ignored Volumes" = "Ігноровані томи";
@@ -148,6 +150,10 @@
 "Options" = "Параметри";
 "Leave empty to use default location" = "Залиште порожнім, щоб використовувати типове місце";
 "Preview: %@" = "Попередній перегляд: %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
 "Custom Mount Point Menu" = "Власна точка монтування…";
 "Use Custom Mount Point" = "Використовувати власну точку монтування";
 "Folder Path" = "Шлях до теки";
@@ -187,3 +193,47 @@
 "The disk is in use. Do you want to force eject it?" = "Диск використовується. Бажаєте примусово вийняти його?";
 "This may result in data loss." = "Це може призвести до втрати даних.";
 "Remember password in Keychain" = "Запам'ятати пароль у Keychain";
+
+// Додаткові рядки, знайдені у SwiftUI
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Відмонтувати всі томи";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - Підключити всі томи";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Щоб використовувати ярлики клавіатури, надайте MountMate доступ Accessibility у Системних налаштуваннях → Конфіденційність і безпека → Доступність.";
+
+"Volume: %@" = "Том: %@";
+"Disk: %@" = "Диск: %@";
+"APFS Container • %@" = "Контейнер APFS • %@";
+
+"Settings" = "Налаштування";
+"Refresh Drives" = "Оновити диски";
+"Retry" = "Повторити";
+"Auto-mounts at login" = "Автоматично монтується при вході";
+"Mount Now" = "Підключити зараз";
+"Edit" = "Редагувати";
+"Delete" = "Видалити";
+
+"Accessibility Permission Required" = "Потрібен дозвіл доступності";
+
+"Add Share" = "Додати мережевий ресурс";
+
+"Optional (Defaults to share name)" = "Необов'язково (За замовчуванням - ім'я ресурсу)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Необов'язково (Гість)";
+
+// Решта рядків
+"MountMate" = "MountMate";
+"Expand All" = "Розгорнути все";
+"Collapse All" = "Згорнути все";
+"Try Again" = "Спробувати знову";
+"Action Failed" = "Операція не вдалася";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ використано / %@ (%@ вільно)";

--- a/MountMate/Resources/uk.lproj/Localizable.strings
+++ b/MountMate/Resources/uk.lproj/Localizable.strings
@@ -61,10 +61,8 @@
 "Block USB Auto-Mount" = "Блокувати автопідключення USB";
 "Unmount All Disks on Sleep" = "Відмонтувати всі диски під час сну";
 "Language" = "Мова";
-"Enable Keyboard Shortcuts" = "Увімкнути комбінації клавіш";
 
 // About & Updates Section
-"About & Updates" = "Про програму та оновлення";
 "Homepage" = "Домашня сторінка";
 "Support Email" = "Електронна пошта підтримки";
 "Donate" = "Пожертвувати";
@@ -185,6 +183,7 @@
 "Custom Mount Point Requires UUID" = "Цей том не має стабільного UUID, тому MountMate не може додати для нього системне правило монтування.";
 "Custom Mount Point Unsupported File System" = "MountMate не зміг визначити правильний тип файлової системи для системного правила монтування цього тому.";
 "Custom Mount Point System Conflict" = "Для цього тому вже існує інший запис /etc/fstab, яким MountMate не керує.";
+"Custom Mount Point System Error" = "MountMate не зміг оновити системне правило монтування.";
 "Custom Mount Point System Save Error" = "MountMate не зміг оновити системне правило монтування.\n\nДеталі:\n%@";
 
 // MARK: - Force Eject

--- a/MountMate/Resources/vi.lproj/Localizable.strings
+++ b/MountMate/Resources/vi.lproj/Localizable.strings
@@ -54,7 +54,6 @@
 "Management" = "Quản lý";
 
 // General Tab
-"Enable Keyboard Shortcuts" = "Bật phím tắt";
 "Show Count in Menu Bar" = "Hiển thị số lượng trên thanh menu";
 "Show Internal Disks" = "Hiển thị ổ đĩa trong";
 "Start MountMate at Login" = "Khởi động cùng máy";
@@ -64,7 +63,6 @@
 "Enable Keyboard Shortcuts" = "Bật phím tắt";
 
 // About & Updates Section
-"About & Updates" = "Giới thiệu & Cập nhật";
 "Homepage" = "Trang chủ";
 "Support Email" = "Email hỗ trợ";
 "Donate" = "Ủng hộ";
@@ -185,6 +183,7 @@
 "Custom Mount Point Requires UUID" = "Ổ này không cung cấp UUID ổn định nên MountMate không thể thêm quy tắc gắn hệ thống cho nó.";
 "Custom Mount Point Unsupported File System" = "MountMate không thể xác định đúng kiểu hệ thống tệp cho quy tắc gắn hệ thống của ổ này.";
 "Custom Mount Point System Conflict" = "Ổ này đã có một mục /etc/fstab khác không do MountMate quản lý.";
+"Custom Mount Point System Error" = "MountMate không thể cập nhật quy tắc gắn hệ thống.";
 "Custom Mount Point System Save Error" = "MountMate không thể cập nhật quy tắc gắn hệ thống.\n\nChi tiết:\n%@";
 
 // MARK: - Force Eject

--- a/MountMate/Resources/vi.lproj/Localizable.strings
+++ b/MountMate/Resources/vi.lproj/Localizable.strings
@@ -148,6 +148,38 @@
 "Options" = "Tùy chọn";
 "Leave empty to use default location" = "Để trống để dùng vị trí mặc định";
 "Preview: %@" = "Xem trước: %@";
+"Custom Mount Point Menu" = "Điểm gắn tùy chỉnh…";
+"Use Custom Mount Point" = "Dùng điểm gắn tùy chỉnh";
+"Folder Path" = "Đường dẫn thư mục";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "Chọn…";
+"Choose" = "Chọn";
+"Reset" = "Đặt lại";
+"Default Path" = "Đường dẫn mặc định";
+"Save" = "Lưu";
+"Create" = "Tạo";
+"Use Folder" = "Dùng thư mục";
+"Custom Mount Point Help" = "Tắt tùy chọn này để dùng vị trí gắn mặc định của macOS.";
+"Custom Mount Point Empty Means Default" = "Để trống để dùng vị trí gắn mặc định của macOS.";
+"Custom Mount Point System Helper" = "Để trống để dùng vị trí gắn mặc định của macOS. Khi lưu, quy tắc gắn hệ thống sẽ được cập nhật và có thể hỏi mật khẩu quản trị một lần.";
+"Custom Mount Point Summary" = "Tùy chỉnh: %@";
+"Create Folder Title" = "Tạo thư mục?";
+"Create Folder Message" = "Thư mục này chưa tồn tại. MountMate có thể tạo nó trước khi lưu.";
+"Folder Not Empty Title" = "Thư mục không trống";
+"Folder Not Empty Message" = "Thư mục đã chọn đang có sẵn tệp. Việc gắn ổ ở đây có thể tạm thời che các tệp đó khi ổ đang được gắn.";
+"Custom Mount Point Empty Path" = "Hãy nhập đường dẫn thư mục.";
+"Custom Mount Point Must Be Absolute" = "Điểm gắn tùy chỉnh phải là đường dẫn tuyệt đối.";
+"Custom Mount Point Cannot Be Root" = "Điểm gắn tùy chỉnh không được là thư mục gốc.";
+"Custom Mount Point In Use" = "Thư mục này đang được dùng bởi phân vùng đã gắn “%@”.";
+"Custom Mount Point Must Be Folder" = "Điểm gắn tùy chỉnh phải là một thư mục.";
+"Custom Mount Point Prepare Fallback" = "MountMate không thể chuẩn bị điểm gắn tùy chỉnh.";
+"Custom Mount Point Prepare Error" = "MountMate không thể chuẩn bị điểm gắn tùy chỉnh.\n\nChi tiết:\n%@";
+"Custom Mount Point Inspect Error" = "MountMate không thể kiểm tra thư mục này.\n\nChi tiết:\n%@";
+"Custom Mount Point Create Error" = "MountMate không thể tạo thư mục này.\n\nChi tiết:\n%@";
+"Custom Mount Point Requires UUID" = "Ổ này không cung cấp UUID ổn định nên MountMate không thể thêm quy tắc gắn hệ thống cho nó.";
+"Custom Mount Point Unsupported File System" = "MountMate không thể xác định đúng kiểu hệ thống tệp cho quy tắc gắn hệ thống của ổ này.";
+"Custom Mount Point System Conflict" = "Ổ này đã có một mục /etc/fstab khác không do MountMate quản lý.";
+"Custom Mount Point System Save Error" = "MountMate không thể cập nhật quy tắc gắn hệ thống.\n\nChi tiết:\n%@";
 
 // MARK: - Force Eject
 //=============================================

--- a/MountMate/Resources/vi.lproj/Localizable.strings
+++ b/MountMate/Resources/vi.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings (Vietnamese)
 */
 
@@ -61,6 +61,7 @@
 "Block USB Auto-Mount" = "Chặn tự động gắn USB";
 "Unmount All Disks on Sleep" = "Tháo tất cả ổ đĩa khi ngủ";
 "Language" = "Ngôn ngữ";
+"Enable Keyboard Shortcuts" = "Bật phím tắt";
 
 // About & Updates Section
 "About & Updates" = "Giới thiệu & Cập nhật";
@@ -68,6 +69,7 @@
 "Support Email" = "Email hỗ trợ";
 "Donate" = "Ủng hộ";
 "Check for Updates..." = "Kiểm tra cập nhật...";
+"About & Updates" = "Giới thiệu & Cập nhật";
 
 // Management Tab
 "Ignored Volumes" = "Phân vùng bị bỏ qua";
@@ -148,6 +150,10 @@
 "Options" = "Tùy chọn";
 "Leave empty to use default location" = "Để trống để dùng vị trí mặc định";
 "Preview: %@" = "Xem trước: %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
 "Custom Mount Point Menu" = "Điểm gắn tùy chỉnh…";
 "Use Custom Mount Point" = "Dùng điểm gắn tùy chỉnh";
 "Folder Path" = "Đường dẫn thư mục";
@@ -187,3 +193,47 @@
 "The disk is in use. Do you want to force eject it?" = "Ổ đĩa đang được sử dụng. Bạn có muốn buộc đẩy ra không?";
 "This may result in data loss." = "Việc này có thể dẫn đến mất dữ liệu.";
 "Remember password in Keychain" = "Ghi nhớ mật khẩu trong Keychain";
+
+// Các chuỗi còn lại
+"MountMate" = "MountMate";
+"Expand All" = "Mở rộng tất cả";
+"Collapse All" = "Thu gọn tất cả";
+"Try Again" = "Thử lại";
+"Action Failed" = "Thao tác thất bại";
+
+// Chuỗi bổ sung được phát hiện trong SwiftUI
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Tháo tất cả phân vùng";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - Gắn tất cả phân vùng";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Để sử dụng phím tắt, vui lòng cấp MountMate quyền Accessibility trong Cài đặt Hệ thống → Quyền riêng tư & Bảo mật → Trợ năng.";
+
+"Volume: %@" = "Phân vùng: %@";
+"Disk: %@" = "Ổ đĩa: %@";
+"APFS Container • %@" = "Bộ chứa APFS • %@";
+
+"Settings" = "Cài đặt";
+"Refresh Drives" = "Làm mới ổ đĩa";
+"Retry" = "Thử lại";
+"Auto-mounts at login" = "Tự động gắn khi đăng nhập";
+"Mount Now" = "Gắn ngay";
+"Edit" = "Chỉnh sửa";
+"Delete" = "Xóa";
+
+"Accessibility Permission Required" = "Cần quyền Trợ năng";
+
+"Add Share" = "Thêm chia sẻ";
+
+"Optional (Defaults to share name)" = "Tùy chọn (Mặc định: tên chia sẻ)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Tùy chọn (Khách)";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ đã sử dụng / %@ (%@ còn trống)";

--- a/MountMate/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hans.lproj/Localizable.strings
@@ -148,6 +148,38 @@
 "Options" = "选项";
 "Leave empty to use default location" = "留空以使用默认位置";
 "Preview: %@" = "预览: %@";
+"Custom Mount Point Menu" = "自定义挂载点…";
+"Use Custom Mount Point" = "使用自定义挂载点";
+"Folder Path" = "文件夹路径";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "选择…";
+"Choose" = "选择";
+"Reset" = "重置";
+"Default Path" = "默认路径";
+"Save" = "保存";
+"Create" = "创建";
+"Use Folder" = "使用文件夹";
+"Custom Mount Point Help" = "关闭此选项可使用 macOS 标准挂载位置。";
+"Custom Mount Point Empty Means Default" = "留空即可使用 macOS 标准挂载位置。";
+"Custom Mount Point System Helper" = "留空即可使用 macOS 标准挂载位置。保存时会更新系统挂载规则，并且可能会要求您输入一次管理员密码。";
+"Custom Mount Point Summary" = "自定义: %@";
+"Create Folder Title" = "创建文件夹？";
+"Create Folder Message" = "此文件夹尚不存在。MountMate 可以在保存前创建它。";
+"Folder Not Empty Title" = "文件夹非空";
+"Folder Not Empty Message" = "所选文件夹已包含文件。挂载到这里时，这些文件在卷已挂载期间可能会被暂时遮住。";
+"Custom Mount Point Empty Path" = "请输入文件夹路径。";
+"Custom Mount Point Must Be Absolute" = "自定义挂载点必须是绝对路径。";
+"Custom Mount Point Cannot Be Root" = "自定义挂载点不能是根目录。";
+"Custom Mount Point In Use" = "该文件夹已被已挂载的卷“%@”使用。";
+"Custom Mount Point Must Be Folder" = "自定义挂载点必须是文件夹。";
+"Custom Mount Point Prepare Fallback" = "MountMate 无法准备自定义挂载点。";
+"Custom Mount Point Prepare Error" = "MountMate 无法准备自定义挂载点。\n\n详细信息：\n%@";
+"Custom Mount Point Inspect Error" = "MountMate 无法检查此文件夹。\n\n详细信息：\n%@";
+"Custom Mount Point Create Error" = "MountMate 无法创建此文件夹。\n\n详细信息：\n%@";
+"Custom Mount Point Requires UUID" = "此卷没有稳定的 UUID，因此 MountMate 无法为其添加系统挂载规则。";
+"Custom Mount Point Unsupported File System" = "MountMate 无法确定此卷系统挂载规则所需的正确文件系统类型。";
+"Custom Mount Point System Conflict" = "此卷已经有一个不受 MountMate 管理的 /etc/fstab 条目。";
+"Custom Mount Point System Save Error" = "MountMate 无法更新系统挂载规则。\n\n详细信息：\n%@";
 
 // MARK: - Force Eject
 //=============================================

--- a/MountMate/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hans.lproj/Localizable.strings
@@ -54,7 +54,6 @@
 "Management" = "管理";
 
 // General Tab
-"Enable Keyboard Shortcuts" = "启用键盘快捷键";
 "Show Count in Menu Bar" = "在菜单栏显示数量";
 "Show Internal Disks" = "显示内置磁盘";
 "Start MountMate at Login" = "登录时启动 MountMate";
@@ -184,6 +183,7 @@
 "Custom Mount Point Requires UUID" = "此卷没有稳定的 UUID，因此 MountMate 无法为其添加系统挂载规则。";
 "Custom Mount Point Unsupported File System" = "MountMate 无法确定此卷系统挂载规则所需的正确文件系统类型。";
 "Custom Mount Point System Conflict" = "此卷已经有一个不受 MountMate 管理的 /etc/fstab 条目。";
+"Custom Mount Point System Error" = "MountMate 无法更新系统挂载规则。";
 "Custom Mount Point System Save Error" = "MountMate 无法更新系统挂载规则。\n\n详细信息：\n%@";
 
 // MARK: - Force Eject

--- a/MountMate/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hans.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Block USB Auto-Mount" = "阻止 USB 自动挂载";
 "Unmount All Disks on Sleep" = "进入睡眠时卸载所有磁盘";
 "Language" = "语言";
+"Enable Keyboard Shortcuts" = "启用键盘快捷键";
 
 // About & Updates Section
 "About & Updates" = "关于与更新";
@@ -148,6 +149,10 @@
 "Options" = "选项";
 "Leave empty to use default location" = "留空以使用默认位置";
 "Preview: %@" = "预览: %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
 "Custom Mount Point Menu" = "自定义挂载点…";
 "Use Custom Mount Point" = "使用自定义挂载点";
 "Folder Path" = "文件夹路径";
@@ -187,3 +192,47 @@
 "The disk is in use. Do you want to force eject it?" = "磁盘正在使用中。您要强制推出吗？";
 "This may result in data loss." = "这可能会导致数据丢失。";
 "Remember password in Keychain" = "在钥匙串中记住密码";
+
+// 新增在 SwiftUI 视图中发现的字符串
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - 卸载所有卷";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - 挂载所有卷";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用键盘快捷键，请在系统设置 → 隐私与安全 → 辅助功能 中授予 MountMate 辅助功能访问权限。";
+
+"Volume: %@" = "卷： %@";
+"Disk: %@" = "磁盘： %@";
+"APFS Container • %@" = "APFS 容器 • %@";
+
+"Settings" = "设置";
+"Refresh Drives" = "刷新磁盘";
+"Retry" = "重试";
+"Auto-mounts at login" = "登录时自动挂载";
+"Mount Now" = "立即挂载";
+"Edit" = "编辑";
+"Delete" = "删除";
+
+"Accessibility Permission Required" = "需要辅助功能权限";
+
+"Add Share" = "添加共享";
+
+"Optional (Defaults to share name)" = "可选（默认使用共享名）";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "可选（访客）";
+
+// 剩余 UI 字符串
+"MountMate" = "MountMate";
+"Expand All" = "全部展开";
+"Collapse All" = "全部折叠";
+"Try Again" = "重试";
+"Action Failed" = "操作失败";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";

--- a/MountMate/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hant.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Block USB Auto-Mount" = "阻止 USB 自動掛載";
 "Unmount All Disks on Sleep" = "進入睡眠模式時卸載所有磁碟";
 "Language" = "語言";
+"Enable Keyboard Shortcuts" = "啟用鍵盤快速鍵";
 
 // About & Updates Section
 "About & Updates" = "關於與更新";
@@ -148,6 +149,10 @@
 "Options" = "選項";
 "Leave empty to use default location" = "留空以使用預設位置";
 "Preview: %@" = "預覽: %@";
+
+
+// MARK: - Custom Mount Point
+//=============================================
 "Custom Mount Point Menu" = "自訂掛載點…";
 "Use Custom Mount Point" = "使用自訂掛載點";
 "Folder Path" = "資料夾路徑";
@@ -187,3 +192,47 @@
 "The disk is in use. Do you want to force eject it?" = "磁碟正在使用中。您要強制退出嗎？";
 "This may result in data loss." = "這可能會導致資料遺失。";
 "Remember password in Keychain" = "在鑰匙圈中記住密碼";
+
+// 剩餘字串
+"MountMate" = "MountMate";
+"Expand All" = "全部展開";
+"Collapse All" = "全部摺疊";
+"Try Again" = "重試";
+"Action Failed" = "操作失敗";
+
+// 新增在 SwiftUI 視圖中發現的字串
+"⌘⇧U - Unmount All Volumes" = "⌘⇧U - 卸載所有卷";
+"⌘⇧M - Mount All Volumes" = "⌘⇧M - 掛載所有卷";
+
+"English" = "English";
+"Français" = "Français";
+"Українська" = "Українська";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁體）";
+
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用鍵盤快速鍵，請在系統設定 → 隱私與安全性 → 輔助使用 中為 MountMate 開啟輔助使用權限。";
+
+"Volume: %@" = "卷： %@";
+"Disk: %@" = "磁碟： %@";
+"APFS Container • %@" = "APFS 容器 • %@";
+
+"Settings" = "設定";
+"Refresh Drives" = "重新整理磁碟";
+"Retry" = "重試";
+"Auto-mounts at login" = "登入時自動掛載";
+"Mount Now" = "立即掛載";
+"Edit" = "編輯";
+"Delete" = "刪除";
+
+"Accessibility Permission Required" = "需要輔助使用權限";
+
+"Add Share" = "新增共用";
+
+"Optional (Defaults to share name)" = "選填（預設為共用名稱）";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "選填（訪客）";
+
+// Disk usage format
+"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";

--- a/MountMate/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hant.lproj/Localizable.strings
@@ -148,6 +148,38 @@
 "Options" = "選項";
 "Leave empty to use default location" = "留空以使用預設位置";
 "Preview: %@" = "預覽: %@";
+"Custom Mount Point Menu" = "自訂掛載點…";
+"Use Custom Mount Point" = "使用自訂掛載點";
+"Folder Path" = "資料夾路徑";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "選擇…";
+"Choose" = "選擇";
+"Reset" = "重設";
+"Default Path" = "預設路徑";
+"Save" = "儲存";
+"Create" = "建立";
+"Use Folder" = "使用資料夾";
+"Custom Mount Point Help" = "關閉此選項即可使用 macOS 標準掛載位置。";
+"Custom Mount Point Empty Means Default" = "留空即可使用 macOS 標準掛載位置。";
+"Custom Mount Point System Helper" = "留空即可使用 macOS 標準掛載位置。儲存時會更新系統掛載規則，並且可能會要求您輸入一次管理員密碼。";
+"Custom Mount Point Summary" = "自訂: %@";
+"Create Folder Title" = "建立資料夾？";
+"Create Folder Message" = "此資料夾尚不存在。MountMate 可以在儲存前建立它。";
+"Folder Not Empty Title" = "資料夾不是空的";
+"Folder Not Empty Message" = "所選資料夾已包含檔案。掛載到此處時，這些檔案在磁碟卷已掛載期間可能會被暫時遮住。";
+"Custom Mount Point Empty Path" = "請輸入資料夾路徑。";
+"Custom Mount Point Must Be Absolute" = "自訂掛載點必須是絕對路徑。";
+"Custom Mount Point Cannot Be Root" = "自訂掛載點不能是根目錄。";
+"Custom Mount Point In Use" = "此資料夾已被已掛載的磁碟卷「%@」使用。";
+"Custom Mount Point Must Be Folder" = "自訂掛載點必須是資料夾。";
+"Custom Mount Point Prepare Fallback" = "MountMate 無法準備自訂掛載點。";
+"Custom Mount Point Prepare Error" = "MountMate 無法準備自訂掛載點。\n\n詳細資料：\n%@";
+"Custom Mount Point Inspect Error" = "MountMate 無法檢查此資料夾。\n\n詳細資料：\n%@";
+"Custom Mount Point Create Error" = "MountMate 無法建立此資料夾。\n\n詳細資料：\n%@";
+"Custom Mount Point Requires UUID" = "此磁碟卷沒有穩定的 UUID，因此 MountMate 無法為它新增系統掛載規則。";
+"Custom Mount Point Unsupported File System" = "MountMate 無法判定此磁碟卷系統掛載規則所需的正確檔案系統類型。";
+"Custom Mount Point System Conflict" = "此磁碟卷已經有一個不是由 MountMate 管理的 /etc/fstab 項目。";
+"Custom Mount Point System Save Error" = "MountMate 無法更新系統掛載規則。\n\n詳細資料：\n%@";
 
 // MARK: - Force Eject
 //=============================================

--- a/MountMate/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hant.lproj/Localizable.strings
@@ -61,7 +61,6 @@
 "Block USB Auto-Mount" = "阻止 USB 自動掛載";
 "Unmount All Disks on Sleep" = "進入睡眠模式時卸載所有磁碟";
 "Language" = "語言";
-"Enable Keyboard Shortcuts" = "啟用鍵盤快速鍵";
 
 // About & Updates Section
 "About & Updates" = "關於與更新";
@@ -184,6 +183,7 @@
 "Custom Mount Point Requires UUID" = "此磁碟卷沒有穩定的 UUID，因此 MountMate 無法為它新增系統掛載規則。";
 "Custom Mount Point Unsupported File System" = "MountMate 無法判定此磁碟卷系統掛載規則所需的正確檔案系統類型。";
 "Custom Mount Point System Conflict" = "此磁碟卷已經有一個不是由 MountMate 管理的 /etc/fstab 項目。";
+"Custom Mount Point System Error" = "MountMate 無法更新系統掛載規則。";
 "Custom Mount Point System Save Error" = "MountMate 無法更新系統掛載規則。\n\n詳細資料：\n%@";
 
 // MARK: - Force Eject

--- a/MountMate/Utilities/AppDelegate.swift
+++ b/MountMate/Utilities/AppDelegate.swift
@@ -6,14 +6,26 @@ import SwiftUI
 
 class AppDelegate: NSObject, NSApplicationDelegate {
   private var cancellables = Set<AnyCancellable>()
+  private var statusItem: NSStatusItem?
+  private let popover = NSPopover()
+  private var eventMonitor: Any?
 
   // MARK: - Application Lifecycle
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
+    NSApp.setActivationPolicy(.accessory)
+    setupStatusItem()
+    setupStatusItemObservers()
     setupErrorObserver()
     setupSleepObserver()
     checkAndRequestFullDiskAccessIfNeeded()
     NetworkMountManager.shared.mountAllAutoShares()
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    if let eventMonitor {
+      NSEvent.removeMonitor(eventMonitor)
+    }
   }
 
   // MARK: - Observers
@@ -35,6 +47,90 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       name: NSWorkspace.willSleepNotification,
       object: nil
     )
+  }
+
+  private func setupStatusItem() {
+    let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    self.statusItem = statusItem
+
+    if let button = statusItem.button {
+      button.target = self
+      button.action = #selector(togglePopover(_:))
+      button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    popover.behavior = .applicationDefined
+    popover.animates = true
+    popover.contentSize = NSSize(width: 350, height: 520)
+    popover.contentViewController = NSHostingController(
+      rootView: PopoverContent {
+        MainView()
+      }
+      .environmentObject(DriveManager.shared)
+    )
+
+    updateStatusItemIcon()
+    installPopoverEventMonitor()
+  }
+
+  private func setupStatusItemObservers() {
+    DriveManager.shared.objectWillChange
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] in
+        self?.updateStatusItemIcon()
+      }
+      .store(in: &cancellables)
+  }
+
+  private func installPopoverEventMonitor() {
+    eventMonitor = NSEvent.addGlobalMonitorForEvents(
+      matching: [.leftMouseDown, .rightMouseDown]
+    ) { [weak self] _ in
+      guard let self, self.popover.isShown else { return }
+      DispatchQueue.main.async {
+        if !CustomMountPointEditorState.shared.isChoosingFolder, NSApp.modalWindow == nil {
+          self.popover.performClose(nil)
+        }
+      }
+    }
+  }
+
+  private func updateStatusItemIcon() {
+    guard let button = statusItem?.button else { return }
+    let iconName: String
+    if DriveManager.shared.isUnmountingAll
+      || DriveManager.shared.busyVolumeIdentifier != nil
+      || DriveManager.shared.busyEjectingIdentifier != nil
+    {
+      iconName = "externaldrive.fill.badge.timemachine"
+    } else if DriveManager.shared.userActionError != nil {
+      iconName = "externaldrive.fill.trianglebadge.exclamationmark"
+    } else {
+      iconName = "externaldrive.fill"
+    }
+
+    button.image = NSImage(systemSymbolName: iconName, accessibilityDescription: "MountMate")
+  }
+
+  @objc private func togglePopover(_ sender: Any?) {
+    guard let button = statusItem?.button else { return }
+    if popover.isShown {
+      if CustomMountPointEditorState.shared.isChoosingFolder { return }
+      popover.performClose(sender)
+      return
+    }
+
+    NSApp.activate(ignoringOtherApps: true)
+    if let contentView = popover.contentViewController?.view {
+      contentView.layoutSubtreeIfNeeded()
+      let fittingSize = contentView.fittingSize
+      popover.contentSize = NSSize(
+        width: max(360, fittingSize.width),
+        height: min(max(480, fittingSize.height), 720)
+      )
+    }
+    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+    popover.contentViewController?.view.window?.makeKey()
   }
 
   // MARK: - Actions

--- a/MountMate/Utilities/Shell.swift
+++ b/MountMate/Utilities/Shell.swift
@@ -240,3 +240,15 @@ private final class ClaimOnce: @unchecked Sendable {
     return true
   }
 }
+
+extension String {
+  var shellQuoted: String {
+    "'" + self.replacingOccurrences(of: "'", with: "'\\''") + "'"
+  }
+
+  var appleScriptStringLiteral: String {
+    "\"" + self
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"") + "\""
+  }
+}

--- a/MountMate/Views/Components/PopoverContent.swift
+++ b/MountMate/Views/Components/PopoverContent.swift
@@ -9,6 +9,5 @@ struct PopoverContent<Content: View>: View {
     VStack(spacing: 0) {
       content()
     }
-    .fixedSize(horizontal: false, vertical: true)
   }
 }

--- a/MountMate/Views/Main/MainView.swift
+++ b/MountMate/Views/Main/MainView.swift
@@ -1,11 +1,67 @@
 //  Created by homielab.com
 
+import AppKit
 import SwiftUI
+
+final class CustomMountPointEditorState: ObservableObject {
+  static let shared = CustomMountPointEditorState()
+
+  @Published var expandedVolumeID: String?
+  @Published var mountPointPath = ""
+  @Published var inlineError: String?
+  @Published var pendingSavePath: String?
+  @Published var selectedFolderURL: URL?
+  @Published var showCreateDirectoryAlert = false
+  @Published var showNonEmptyDirectoryAlert = false
+  @Published var isChoosingFolder = false
+  weak var hostWindow: NSWindow?
+
+  func sync(from persistedPath: String?) {
+    mountPointPath = persistedPath ?? ""
+    inlineError = nil
+    pendingSavePath = nil
+    selectedFolderURL = nil
+    showCreateDirectoryAlert = false
+    showNonEmptyDirectoryAlert = false
+    isChoosingFolder = false
+  }
+
+  func collapse() {
+    expandedVolumeID = nil
+    inlineError = nil
+    pendingSavePath = nil
+    selectedFolderURL = nil
+    showCreateDirectoryAlert = false
+    showNonEmptyDirectoryAlert = false
+    isChoosingFolder = false
+  }
+}
+
+struct HostingWindowReader: NSViewRepresentable {
+  let onResolve: (NSWindow?) -> Void
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      onResolve(view.window)
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    DispatchQueue.main.async {
+      onResolve(nsView.window)
+    }
+  }
+}
 
 struct MainView: View {
   @EnvironmentObject var driveManager: DriveManager
   @ObservedObject var persistence = PersistenceManager.shared
   @ObservedObject var networkManager = NetworkMountManager.shared
+  @State private var initialLoadTimer = Timer.publish(every: 0.25, on: .main, in: .common)
+    .autoconnect()
+  @ObservedObject private var customMountPointEditor = CustomMountPointEditorState.shared
 
   private var internalDisks: [PhysicalDisk] {
     (driveManager.physicalDisks ?? []).filter { $0.type == .internalDisk && $0.hasVisibleContent }
@@ -40,12 +96,18 @@ struct MainView: View {
           externalDisks: externalDisks,
           diskImages: diskImages,
           networkShares: persistence.networkShares,
-          manualShares: networkManager.manuallyConnectedShares
+          manualShares: networkManager.manuallyConnectedShares,
+          customMountPointEditor: customMountPointEditor
         )
       }
     }
     .frame(width: 350)
     .padding(.bottom, 8)
+    .background(
+      HostingWindowReader { window in
+        customMountPointEditor.hostWindow = window
+      }
+    )
     .onAppear {
       NSApp.activate(ignoringOtherApps: true)
       driveManager.refreshDrives()
@@ -76,22 +138,35 @@ struct DriveListView: View {
   let diskImages: [PhysicalDisk]
   let networkShares: [NetworkShare]
   let manualShares: [NetworkShare]
+  @ObservedObject var customMountPointEditor: CustomMountPointEditorState
 
   var body: some View {
     List {
       if !internalDisks.isEmpty {
         Section(header: Text("Internal Disks")) {
-          ForEach(internalDisks) { disk in DiskAndVolumesView(disk: disk) }
+          ForEach(internalDisks) { disk in
+            DiskAndVolumesView(
+              disk: disk,
+              customMountPointEditor: customMountPointEditor)
+          }
         }
       }
       if !externalDisks.isEmpty {
         Section(header: Text("External Disks")) {
-          ForEach(externalDisks) { disk in DiskAndVolumesView(disk: disk) }
+          ForEach(externalDisks) { disk in
+            DiskAndVolumesView(
+              disk: disk,
+              customMountPointEditor: customMountPointEditor)
+          }
         }
       }
       if !diskImages.isEmpty {
         Section(header: Text("Disk Images")) {
-          ForEach(diskImages) { disk in DiskAndVolumesView(disk: disk) }
+          ForEach(diskImages) { disk in
+            DiskAndVolumesView(
+              disk: disk,
+              customMountPointEditor: customMountPointEditor)
+          }
         }
       }
       if !networkShares.isEmpty {
@@ -113,6 +188,7 @@ struct DriveListView: View {
 // MARK: - Hierarchical Helper & Row Views
 struct DiskAndVolumesView: View {
   let disk: PhysicalDisk
+  @ObservedObject var customMountPointEditor: CustomMountPointEditorState
   @State private var isExpanded = true
   @EnvironmentObject var manager: DriveManager  // Make sure manager is available
   @AppStorage("showOnlyVolumes") private var showOnlyVolumes = false
@@ -128,14 +204,20 @@ struct DiskAndVolumesView: View {
       }
       if isExpanded || showOnlyVolumes {
         ForEach(disk.partitions) { partition in
-          VolumeRowView(volume: partition).padding(.leading, showOnlyVolumes ? 0 : 24)
+          VolumeRowView(
+            volume: partition,
+            customMountPointEditor: customMountPointEditor)
+            .padding(.leading, showOnlyVolumes ? 0 : 24)
         }
         ForEach(visibleContainers) { container in
           if !showOnlyVolumes {
             ContainerRowView(container: container)
           }
           ForEach(container.volumes) { volume in
-            VolumeRowView(volume: volume).padding(.leading, showOnlyVolumes ? 0 : 48)
+            VolumeRowView(
+              volume: volume,
+              customMountPointEditor: customMountPointEditor)
+              .padding(.leading, showOnlyVolumes ? 0 : 48)
           }
         }
       }
@@ -240,10 +322,13 @@ struct ContainerRowView: View {
 
 struct VolumeRowView: View {
   let volume: Volume
+  @ObservedObject var customMountPointEditor: CustomMountPointEditorState
   @EnvironmentObject var manager: DriveManager
   @ObservedObject private var persistence = PersistenceManager.shared
   @State private var isHovering = false
   private var isLoading: Bool { manager.busyVolumeIdentifier == volume.id }
+  private var customMountPoint: String? { persistence.customMountPoint(for: volume)?.mountPoint }
+  private var isCustomMountPointExpanded: Bool { customMountPointEditor.expandedVolumeID == volume.id }
 
   private func usageColor(for percentage: Double) -> Color {
     if percentage > 0.9 { return .red } else if percentage > 0.75 { return .orange }
@@ -253,6 +338,30 @@ struct VolumeRowView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 2) {
       HStack(spacing: 0) {
+        Button(action: {
+          syncEditorStateFromPersistence()
+          withAnimation(.easeInOut(duration: 0.18)) {
+            customMountPointEditor.expandedVolumeID = isCustomMountPointExpanded ? nil : volume.id
+          }
+        }) {
+          Image(systemName: "chevron.right")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.white.opacity(0.9))
+            .rotationEffect(.degrees(isCustomMountPointExpanded ? 90 : 0))
+            .frame(width: 12, height: 12)
+            .padding(8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .frame(width: 28, height: 28, alignment: .center)
+        .contentShape(Rectangle())
+        .disabled(isLoading)
+        .help(
+          NSLocalizedString(
+            "Custom Mount Point Menu",
+            comment: "Volume context menu custom mount point action"))
+        .padding(.trailing, 8)
+
         HStack {
           ZStack {
             Image(systemName: "externaldrive")
@@ -285,6 +394,19 @@ struct VolumeRowView: View {
               }
             } else {
               Text("Unmounted").font(.caption).foregroundColor(.secondary)
+            }
+            if let customMountPoint {
+              Text(
+                String(
+                  format: NSLocalizedString(
+                    "Custom Mount Point Summary",
+                    comment: "Volume row custom mount point summary"),
+                  customMountPoint))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .help(customMountPoint)
             }
           }
           Spacer()
@@ -323,6 +445,11 @@ struct VolumeRowView: View {
       .cornerRadius(5)
       .onHover { hovering in
         self.isHovering = hovering
+      }
+      .onAppear {
+        if isCustomMountPointExpanded {
+          syncEditorStateFromPersistence()
+        }
       }
       .contextMenu {
         if volume.isMounted {
@@ -379,6 +506,16 @@ struct VolumeRowView: View {
         } label: {
           Label("Don't Auto-Mount This Volume", systemImage: "hand.raised")
         }
+        Button {
+          syncEditorStateFromPersistence()
+          customMountPointEditor.expandedVolumeID = isCustomMountPointExpanded ? nil : volume.id
+        } label: {
+          Label(
+            NSLocalizedString(
+              "Custom Mount Point Menu",
+              comment: "Volume context menu custom mount point action"),
+            systemImage: "folder.badge.gearshape")
+        }
         Divider()
         Button(role: .destructive) {
           if !PersistenceManager.shared.ignore(volume: volume) {
@@ -390,6 +527,16 @@ struct VolumeRowView: View {
           Label("Ignore This Volume", systemImage: "eye.slash")
         }
 
+      }
+
+      if isCustomMountPointExpanded {
+        InlineCustomMountPointEditor(
+          volume: volume,
+          editorState: customMountPointEditor,
+          onClose: {
+            customMountPointEditor.collapse()
+          })
+          .padding(.leading, 32)
       }
 
       if !volume.snapshots.isEmpty {
@@ -416,6 +563,226 @@ struct VolumeRowView: View {
       message: message,
       kind: .basic
     )
+  }
+
+  private func syncEditorStateFromPersistence() {
+    customMountPointEditor.sync(from: customMountPoint)
+  }
+}
+
+struct InlineCustomMountPointEditor: View {
+  let volume: Volume
+  @EnvironmentObject private var driveManager: DriveManager
+  @ObservedObject private var persistence = PersistenceManager.shared
+  @ObservedObject var editorState: CustomMountPointEditorState
+  let onClose: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      TextField(
+        NSLocalizedString("Folder Path", comment: "Custom mount point path field"),
+        text: $editorState.mountPointPath,
+        prompt: Text(
+          NSLocalizedString(
+            "Custom Mount Point Path Prompt",
+            comment: "Custom mount point path placeholder")))
+        .textFieldStyle(.roundedBorder)
+        .foregroundStyle(.white)
+
+      HStack(spacing: 8) {
+        Button(NSLocalizedString("Choose Folder", comment: "Choose folder button")) {
+          chooseFolder()
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.white)
+
+        Button(NSLocalizedString("Default Path", comment: "Default path button")) {
+          editorState.mountPointPath = ""
+          editorState.inlineError = nil
+          editorState.pendingSavePath = nil
+          editorState.selectedFolderURL = nil
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.white)
+
+        Spacer()
+      }
+
+      Text(
+        NSLocalizedString(
+          "Custom Mount Point System Helper",
+          comment: "Custom mount point helper text"))
+        .font(.caption)
+        .foregroundStyle(.white.opacity(0.92))
+        .lineLimit(nil)
+        .fixedSize(horizontal: false, vertical: true)
+
+      if let inlineError = editorState.inlineError {
+        Text(inlineError)
+          .font(.caption)
+          .foregroundStyle(.red)
+          .lineLimit(nil)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      HStack {
+        Button(NSLocalizedString("Cancel", comment: "Cancel button")) {
+          onClose()
+        }
+        .foregroundStyle(.white)
+        Spacer()
+        Button(NSLocalizedString("Save", comment: "Save button")) {
+          save()
+        }
+        .buttonStyle(.borderedProminent)
+      }
+    }
+    .padding(10)
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color.white.opacity(0.08))
+    )
+    .alert(
+      NSLocalizedString("Create Folder Title", comment: "Create folder alert title"),
+      isPresented: $editorState.showCreateDirectoryAlert)
+    {
+      Button(NSLocalizedString("Create", comment: "Create button")) {
+        createPendingDirectoryAndSave()
+      }
+      Button(NSLocalizedString("Cancel", comment: "Cancel button"), role: .cancel) {}
+    } message: {
+      Text(
+        NSLocalizedString(
+          "Create Folder Message",
+          comment: "Create folder alert message"))
+    }
+    .alert(
+      NSLocalizedString("Folder Not Empty Title", comment: "Non-empty folder alert title"),
+      isPresented: $editorState.showNonEmptyDirectoryAlert)
+    {
+      Button(NSLocalizedString("Use Folder", comment: "Use folder button")) {
+        commitPendingSave()
+      }
+      Button(NSLocalizedString("Cancel", comment: "Cancel button"), role: .cancel) {}
+    } message: {
+      Text(
+        NSLocalizedString(
+          "Folder Not Empty Message",
+          comment: "Non-empty folder alert message"))
+    }
+  }
+
+  private func chooseFolder() {
+    let panel = NSOpenPanel()
+    panel.canChooseFiles = false
+    panel.canChooseDirectories = true
+    panel.canCreateDirectories = true
+    panel.allowsMultipleSelection = false
+    panel.prompt = NSLocalizedString("Choose", comment: "Choose button")
+    editorState.isChoosingFolder = true
+
+    let currentPath = driveManager.normalizedMountPointPath(editorState.mountPointPath)
+    if !currentPath.isEmpty {
+      panel.directoryURL = URL(fileURLWithPath: currentPath)
+    }
+
+    panel.begin { response in
+      defer {
+        editorState.isChoosingFolder = false
+        NSApp.activate(ignoringOtherApps: true)
+      }
+      guard response == .OK else { return }
+        editorState.mountPointPath = panel.url?.path ?? editorState.mountPointPath
+        editorState.selectedFolderURL = panel.url
+        editorState.inlineError = nil
+      }
+    }
+
+  private func save() {
+    editorState.inlineError = nil
+
+    let normalizedPath = driveManager.normalizedMountPointPath(editorState.mountPointPath)
+    editorState.mountPointPath = normalizedPath
+
+    guard !normalizedPath.isEmpty else {
+      if let error = persistence.removeCustomMountPoint(for: volume) {
+        editorState.inlineError = error
+        return
+      }
+      if volume.isMounted {
+        driveManager.remount(volume: volume)
+      }
+      onClose()
+      return
+    }
+
+    if let validationError = driveManager.customMountPointValidationError(
+      for: normalizedPath, excluding: volume)
+    {
+      editorState.inlineError = validationError
+      return
+    }
+
+    do {
+      let directoryState = try driveManager.inspectDirectory(at: normalizedPath)
+      editorState.pendingSavePath = normalizedPath
+      if editorState.selectedFolderURL?.path != normalizedPath {
+        editorState.selectedFolderURL = nil
+      }
+
+      if !directoryState.exists {
+        editorState.showCreateDirectoryAlert = true
+        return
+      }
+
+      guard directoryState.isDirectory else {
+        editorState.inlineError = NSLocalizedString(
+          "Custom Mount Point Must Be Folder",
+          comment: "Custom mount point validation")
+        return
+      }
+
+      if !directoryState.isEmpty {
+        editorState.showNonEmptyDirectoryAlert = true
+        return
+      }
+
+      commitPendingSave()
+    } catch {
+      editorState.inlineError = String(
+        format: NSLocalizedString(
+          "Custom Mount Point Inspect Error",
+          comment: "Custom mount point validation"), error.localizedDescription)
+    }
+  }
+
+  private func createPendingDirectoryAndSave() {
+    guard let path = editorState.pendingSavePath else { return }
+
+    do {
+      try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+      commitPendingSave()
+    } catch {
+      editorState.inlineError = String(
+        format: NSLocalizedString(
+          "Custom Mount Point Create Error",
+          comment: "Custom mount point validation"), error.localizedDescription)
+    }
+  }
+
+  private func commitPendingSave() {
+    guard let path = editorState.pendingSavePath else { return }
+    let selectedFolderURL =
+      editorState.selectedFolderURL?.path == path ? editorState.selectedFolderURL : nil
+    if let error = persistence.applyCustomMountPoint(path, selectedURL: selectedFolderURL, for: volume)
+    {
+      editorState.inlineError = error
+      return
+    }
+    if volume.isMounted {
+      driveManager.remount(volume: volume)
+    }
+    onClose()
   }
 }
 

--- a/MountMate/Views/Main/MainView.swift
+++ b/MountMate/Views/Main/MainView.swift
@@ -265,8 +265,10 @@ struct DiskHeaderRow: View {
             Text(error).font(.caption).foregroundColor(.orange).lineLimit(1).truncationMode(.tail)
           } else if let total = disk.totalSize, let used = disk.usedSpace, let free = disk.freeSpace
           {
-            Text("\(used) used / \(total) (\(free) free)").font(.caption).foregroundColor(
-              .secondary)
+            Text(String(
+              format: NSLocalizedString("DiskUsageUsedFree", comment: "Disk usage format: used / total (free)"),
+              used, total, free))
+            .font(.caption).foregroundColor(.secondary)
           } else {
             Text(disk.connectionType).font(.caption).foregroundColor(.secondary)
           }
@@ -387,8 +389,8 @@ struct VolumeRowView: View {
               volume.isMounted ? .primary : .secondary)
             if volume.isMounted {
               if let total = volume.totalSize, let used = volume.usedSpace {
-                Text("\(used) / \(total)").font(.caption).foregroundColor(
-                  .secondary)
+                // Keep simple used/total; localize only if desired separately
+                Text(String(format: "%@ / %@", used, total)).font(.caption).foregroundColor(.secondary)
               } else if let fsType = volume.fileSystemType {
                 Text(fsType).font(.caption).foregroundColor(.secondary)
               }
@@ -686,17 +688,23 @@ struct InlineCustomMountPointEditor: View {
       panel.directoryURL = URL(fileURLWithPath: currentPath)
     }
 
-    panel.begin { response in
+    let completion: (NSApplication.ModalResponse) -> Void = { response in
       defer {
         editorState.isChoosingFolder = false
         NSApp.activate(ignoringOtherApps: true)
       }
       guard response == .OK else { return }
-        editorState.mountPointPath = panel.url?.path ?? editorState.mountPointPath
-        editorState.selectedFolderURL = panel.url
-        editorState.inlineError = nil
-      }
+      editorState.mountPointPath = panel.url?.path ?? editorState.mountPointPath
+      editorState.selectedFolderURL = panel.url
+      editorState.inlineError = nil
     }
+
+    if let hostWindow = editorState.hostWindow {
+      panel.beginSheetModal(for: hostWindow, completionHandler: completion)
+    } else {
+      panel.begin(completionHandler: completion)
+    }
+  }
 
   private func save() {
     editorState.inlineError = nil

--- a/MountMate/Views/Main/MainView.swift
+++ b/MountMate/Views/Main/MainView.swift
@@ -59,8 +59,6 @@ struct MainView: View {
   @EnvironmentObject var driveManager: DriveManager
   @ObservedObject var persistence = PersistenceManager.shared
   @ObservedObject var networkManager = NetworkMountManager.shared
-  @State private var initialLoadTimer = Timer.publish(every: 0.25, on: .main, in: .common)
-    .autoconnect()
   @ObservedObject private var customMountPointEditor = CustomMountPointEditorState.shared
 
   private var internalDisks: [PhysicalDisk] {

--- a/MountMate/Views/Settings/SettingsView.swift
+++ b/MountMate/Views/Settings/SettingsView.swift
@@ -37,9 +37,10 @@ struct GeneralSettingsView: View {
         as? [String],
       let firstLanguage = preferredLanguages.first
     else { return "en" }
+    if firstLanguage.starts(with: "fr") { return "fr" }
+    if firstLanguage.starts(with: "uk") { return "uk" }
     if firstLanguage.starts(with: "vi") { return "vi" }
     if firstLanguage.starts(with: "ru") { return "ru" }
-    if firstLanguage.starts(with: "uk") { return "uk" }
     if firstLanguage.starts(with: "zh-Hant")
       || firstLanguage.starts(with: "zh-TW")
       || firstLanguage.starts(with: "zh-HK")
@@ -93,6 +94,7 @@ struct GeneralSettingsView: View {
         }
         Picker("Language", selection: $selectedLanguage) {
           Text("English").tag("en")
+          Text("Français").tag("fr")
           Text("Українська").tag("uk")
           Text("Русский").tag("ru")
           Text("Tiếng Việt").tag("vi")


### PR DESCRIPTION
## Summary
- add an inline per-volume custom mount point editor in the menu bar UI
- persist custom mount point settings by stable volume identity, including bookmark-backed folder selection metadata
- apply custom mount points through managed `/etc/fstab` entries for normal and automatic mounts
- preserve current `main` functionality, including manual network shares, volume-only filtering, RAID handling, and the direct process runner
- add and update localizations, including French
- address the previous review feedback (safe process calls, longer administrator prompt timeout, robust fstab matching, correct panel presentation, and shared SwiftUI ownership)

## Testing
- `xcodebuild -project MountMate.xcodeproj -scheme MountMate -configuration Debug -derivedDataPath .codex-build/DerivedData CODE_SIGNING_ALLOWED=NO build`

Replaces the PRs accidentally opened against the fork.