### PR TITLE
fix(localization)

### DIFF
--- a/MountMate/Managers/DriveManager.swift
+++ b/MountMate/Managers/DriveManager.swift
@@ -794,7 +794,7 @@ class DriveManager: ObservableObject {
         String(
           format: NSLocalizedString(
             "Failed to eject “%@” because one of its volumes is busy or in use.",
-            comment: "Error message"), name) + "\n\nDetails:\n\(error)"
+            comment: "Error message"), name) + "\n\n" + NSLocalizedString("Details", comment: "Error details prefix") + ":\n" + error
       if let disk = disk {
         kind = .forceEject { self.forceEject(disk: disk) }
       } else {
@@ -820,13 +820,13 @@ class DriveManager: ObservableObject {
           String(
             format: NSLocalizedString(
               "Failed to %@ “%@” because it is currently in use by “%@”.",
-              comment: "Error message"), verb, name, proc) + "\n\nDetails:\n\(error)"
+              comment: "Error message"), verb, name, proc) + "\n\n" + NSLocalizedString("Details", comment: "Error details prefix") + ":\n" + error
       } else {
         message =
           String(
             format: NSLocalizedString(
               "Failed to %@ “%@” because it is currently in use by another application.",
-              comment: "Error message"), verb, name) + "\n\nDetails:\n\(error)"
+              comment: "Error message"), verb, name) + "\n\n" + NSLocalizedString("Details", comment: "Error details prefix") + ":\n" + error
       }
 
       if operation == .eject, let disk = disk {
@@ -850,7 +850,7 @@ class DriveManager: ObservableObject {
         verb = "eject"
       }
       message =
-        "\(String(format: NSLocalizedString("An unknown error occurred while trying to %@ “%@”.", comment: "Error message"), verb, name))\n\nDetails:\n\(error)"
+        "\(String(format: NSLocalizedString("An unknown error occurred while trying to %@ “%@”.", comment: "Error message"), verb, name))\n\n" + NSLocalizedString("Details", comment: "Error details prefix") + ":\n\(error)"
       kind = .basic
     }
     self.userActionError = AppAlert(title: title, message: message, kind: kind)

--- a/MountMate/Resources/en.lproj/Localizable.strings
+++ b/MountMate/Resources/en.lproj/Localizable.strings
@@ -32,6 +32,8 @@
 
 "Unknown" = "Unknown";
 "Unmounted" = "Unmounted";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "Disk Image";
 
 
 // MARK: - Context Menus
@@ -47,20 +49,36 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "MountMate Settings";
-
 // Tabs
 "General" = "General";
 "Management" = "Management";
+"Network Shares" = "Network Shares";
 
-// General Tab
-"Enable Keyboard Shortcuts" = "Enable Keyboard Shortcuts";
+// Display Section
+"Display" = "Display";
 "Show Count in Menu Bar" = "Show Count in Menu Bar";
 "Show Internal Disks" = "Show Internal Disks";
+"Show Only Volumes" = "Show Only Volumes";
+
+// Behavior Section
+"Behavior" = "Behavior";
 "Start MountMate at Login" = "Start MountMate at Login";
 "Block USB Auto-Mount" = "Block USB Auto-Mount";
 "Unmount All Disks on Sleep" = "Unmount All Disks on Sleep";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "Shortcuts & Language";
+"Enable Keyboard Shortcuts" = "Enable Keyboard Shortcuts";
+"Unmount All Volumes" = "Unmount All Volumes";
+"Mount All Volumes" = "Mount All Volumes";
 "Language" = "Language";
+"English" = "English";
+"Français" = "French";
+"Українська" = "Ukrainian";
+"Русский" = "Russian";
+"Tiếng Việt" = "Vietnamese";
+"中文（简体）" = "Chinese (Simplified)";
+"中文（繁体）" = "Chinese (Traditional)";
 
 // About & Updates Section
 "About & Updates" = "About & Updates";
@@ -93,6 +111,9 @@
 "Unmount Failed" = "Unmount Failed";
 "“%@” is locked" = "“%@” is locked";
 "Full Disk Access Recommended" = "Full Disk Access Recommended";
+"Action Failed" = "Action Failed";
+"Accessibility Permission Required" = "Accessibility Permission Required";
+"Restart Required" = "Restart Required";
 
 // Buttons
 "OK" = "OK";
@@ -100,6 +121,14 @@
 "Cancel" = "Cancel";
 "Open System Settings" = "Open System Settings";
 "Later" = "Later";
+"Retry" = "Retry";
+"Try Again" = "Try Again";
+"Force Eject" = "Force Eject";
+"Force Unmount" = "Force Unmount";
+"Remember password in Keychain" = "Remember password in Keychain";
+"Restart Now" = "Restart Now";
+"MountMate" = "MountMate";
+"Details" = "Details";
 
 // Verbs for error messages
 "unmount" = "unmount";
@@ -107,7 +136,6 @@
 "mount" = "mount";
 
 // Error Messages & Formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security.";
 "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal.";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "Failed to eject “%@” because one of its volumes is busy or in use.";
 "Failed to %@ “%@” because it is currently in use by another application." = "Failed to %@ “%@” because it is currently in use by another application.";
@@ -117,53 +145,70 @@
 "Password" = "Password";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel.";
 "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect.";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security.";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "Could not save settings for “%@” because it does not have a unique identifier (UUID).";
 
-// MARK: - App Lifecycle & Loading
-//=============================================
+// Disk usage format
+"DiskUsageUsedFree" = "%@ used / %@ (%@ free)";
 
+// App Lifecycle
 "Loading Disks..." = "Loading Disks...";
-"Restart Required" = "Restart Required";
 "Please restart MountMate for the language change to take effect." = "Please restart MountMate for the language change to take effect.";
-"Restart Now" = "Restart Now";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility.";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "Network Shares";
+
 "Add Share" = "Add Share";
 "Add Network Share" = "Add Network Share";
 "Edit Network Share" = "Edit Network Share";
-"Server Address" = "Server Address";
-"Share Name/Path" = "Share Name/Path";
-"Username" = "Username";
-"Password" = "Password";
-"Custom Mount Point" = "Custom Mount Point";
-"Mount at Login" = "Mount at Login";
 "MountMate can automatically mount these SMB shares at login." = "MountMate can automatically mount these SMB shares at login.";
 "No Network Shares Configured" = "No Network Shares Configured";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "Add your SMB or NAS network shares here to mount them automatically or on demand.";
+"Saved Network Shares" = "Saved Network Shares";
+"Manually Connected Shares" = "Manually Connected Shares";
+"Eject All Manually Connected Shares" = "Eject All Manually Connected Shares";
+"Auto-mount" = "Auto-mount";
+"Auto-mounts at login" = "Auto-mounts at login";
+"Mount Share" = "Mount Share";
+"Unmount Share" = "Unmount Share";
+"Edit Share" = "Edit Share";
+"Delete Share" = "Delete Share";
+"Remove" = "Remove";
 "Mounted" = "Mounted";
 "Not Mounted" = "Not Mounted";
 "Display Name" = "Display Name";
 "Connection" = "Connection";
 "Credentials" = "Credentials";
 "Options" = "Options";
+"Server Address" = "Server Address";
+"Share Name/Path" = "Share Name/Path";
+"Username" = "Username";
+"Custom Mount Point" = "Custom Mount Point";
+"Mount at Login" = "Mount at Login";
 "Leave empty to use default location" = "Leave empty to use default location";
-"Preview: %@" = "Preview: %@";
+"Optional (Defaults to share name)" = "Optional (Defaults to share name)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Optional (Guest)";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "Custom Mount Point…";
 "Use Custom Mount Point" = "Use custom mount point";
 "Folder Path" = "Folder Path";
 "Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
 "Choose Folder" = "Choose…";
 "Choose" = "Choose";
-"Reset" = "Reset";
+"Choose..." = "Choose…";
+"Select custom mount directory" = "Select custom mount directory";
 "Default Path" = "Default Path";
 "Save" = "Save";
 "Create" = "Create";
 "Use Folder" = "Use Folder";
-"Custom Mount Point Empty Means Default" = "Leave this empty to use the standard macOS mount location.";
 "Custom Mount Point System Helper" = "Leave this empty to use the standard macOS mount location. Saving updates the system mount rule and may ask for your admin password once.";
 "Custom Mount Point Summary" = "Custom: %@";
 "Create Folder Title" = "Create Folder?";
@@ -175,8 +220,6 @@
 "Custom Mount Point Cannot Be Root" = "The custom mount point cannot be the root folder.";
 "Custom Mount Point In Use" = "The folder is already being used by the mounted volume “%@”.";
 "Custom Mount Point Must Be Folder" = "The custom mount point must be a folder.";
-"Custom Mount Point Prepare Fallback" = "MountMate could not prepare the custom mount point.";
-"Custom Mount Point Prepare Error" = "MountMate could not prepare the custom mount point.\n\nDetails:\n%@";
 "Custom Mount Point Inspect Error" = "MountMate could not inspect this folder.\n\nDetails:\n%@";
 "Custom Mount Point Create Error" = "MountMate could not create this folder.\n\nDetails:\n%@";
 "Custom Mount Point Requires UUID" = "This volume does not expose a stable UUID, so MountMate cannot add a system mount rule for it.";
@@ -184,54 +227,10 @@
 "Custom Mount Point System Conflict" = "This volume already has a different /etc/fstab entry that is not managed by MountMate.";
 "Custom Mount Point System Error" = "MountMate could not update the system mount rule.";
 "Custom Mount Point System Save Error" = "MountMate could not update the system mount rule.\n\nDetails:\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "Force Eject";
-"The disk is in use. Do you want to force eject it?" = "The disk is in use. Do you want to force eject it?";
-"This may result in data loss." = "This may result in data loss.";
-"Remember password in Keychain" = "Remember password in Keychain";
 
-// Additional strings discovered in SwiftUI views
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Unmount All Volumes";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - Mount All Volumes";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁体）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility.";
-
-"Volume: %@" = "Volume: %@";
-"Disk: %@" = "Disk: %@";
-"APFS Container • %@" = "APFS Container • %@";
-
-"Settings" = "Settings";
-"Refresh Drives" = "Refresh Drives";
-"Retry" = "Retry";
-"Auto-mounts at login" = "Auto-mounts at login";
-"Mount Now" = "Mount Now";
-"Edit" = "Edit";
-"Delete" = "Delete";
-
-"Accessibility Permission Required" = "Accessibility Permission Required";
-
-"Add Share" = "Add Share";
-
-"Optional (Defaults to share name)" = "Optional (Defaults to share name)";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "Optional (Guest)";
-
-// Remaining UI strings
-"MountMate" = "MountMate";
-"Expand All" = "Expand All";
-"Collapse All" = "Collapse All";
-"Try Again" = "Try Again";
-"Action Failed" = "Action Failed";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ used / %@ (%@ free)";
+"Preview: %@" = "Preview: %@";

--- a/MountMate/Resources/fr.lproj/Localizable.strings
+++ b/MountMate/Resources/fr.lproj/Localizable.strings
@@ -16,7 +16,11 @@
 // MARK: - Action Buttons & Tooltips
 //=============================================
 
+"Expand All" = "Tout développer";
+"Collapse All" = "Tout réduire";
 "Unmount All" = "Tout démonter";
+"Settings" = "Paramètres";
+"Refresh Drives" = "Actualiser les disques";
 "Eject" = "Éjecter";
 "Mount" = "Monter";
 "Unmount" = "Démonter";
@@ -28,6 +32,8 @@
 
 "Unknown" = "Inconnu";
 "Unmounted" = "Non monté";
+"Apple RAID" = "RAID Apple";
+"Disk Image" = "Image disque";
 
 
 // MARK: - Context Menus
@@ -43,26 +49,43 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "Réglages de MountMate";
-
 // Tabs
 "General" = "Général";
 "Management" = "Gestion";
+"Network Shares" = "Partages réseau";
 
-// General Tab
+// Display Section
+"Display" = "Affichage";
+"Show Count in Menu Bar" = "Afficher le compteur dans la barre de menus";
 "Show Internal Disks" = "Afficher les disques internes";
+"Show Only Volumes" = "Afficher uniquement les volumes";
+
+// Behavior Section
+"Behavior" = "Comportement";
 "Start MountMate at Login" = "Lancer MountMate à l'ouverture de session";
 "Block USB Auto-Mount" = "Bloquer le montage automatique des périphériques USB";
 "Unmount All Disks on Sleep" = "Démonter tous les disques à la mise en veille";
-"Language" = "Langue";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "Raccourcis & Langue";
 "Enable Keyboard Shortcuts" = "Activer les raccourcis clavier";
+"Unmount All Volumes" = "Démonter tous les volumes";
+"Mount All Volumes" = "Monter tous les volumes";
+"Language" = "Langue";
+"English" = "Anglais";
+"Français" = "Français";
+"Українська" = "Ukrainien";
+"Русский" = "Russe";
+"Tiếng Việt" = "Vietnamien";
+"中文（简体）" = "Chinois (simplifié)";
+"中文（繁体）" = "Chinois (traditionnel)";
 
 // About & Updates Section
+"About & Updates" = "À propos & Mises à jour";
 "Homepage" = "Page d'accueil";
 "Support Email" = "E-mail du support";
 "Donate" = "Faire un don";
 "Check for Updates..." = "Rechercher des mises à jour...";
-"About & Updates" = "À propos & Mises à jour";
 
 // Management Tab
 "Ignored Volumes" = "Volumes ignorés";
@@ -88,13 +111,24 @@
 "Unmount Failed" = "Échec du démontage";
 "“%@” is locked" = "« %@ » est verrouillé";
 "Full Disk Access Recommended" = "Accès complet au disque recommandé";
+"Action Failed" = "Échec de l'action";
+"Accessibility Permission Required" = "Permission Accessibilité requise";
+"Restart Required" = "Redémarrage requis";
 
 // Buttons
 "OK" = "OK";
 "Unlock" = "Déverrouiller";
 "Cancel" = "Annuler";
-"Open System Settings" = "Ouvrir les Réglages Système...";
+"Open System Settings" = "Ouvrir les Réglages Système";
 "Later" = "Plus tard";
+"Retry" = "Réessayer";
+"Try Again" = "Réessayer";
+"Force Eject" = "Forcer l'éjection";
+"Force Unmount" = "Forcer le démontage";
+"Remember password in Keychain" = "Mémoriser le mot de passe dans le Trousseau";
+"Restart Now" = "Redémarrer maintenant";
+"MountMate" = "MountMate";
+"Details" = "Détails";
 
 // Verbs for error messages
 "unmount" = "démonter";
@@ -102,62 +136,79 @@
 "mount" = "monter";
 
 // Error Messages & Formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nVeuillez accorder à MountMate l'accès complet au disque dans Réglages Système > Confidentialité et sécurité.";
-"The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "La partition « EFI » ne peut pas être montée directement. Il s'agit d'une partition système spéciale, et ce comportement est normal.";
+"The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "La partition « EFI » ne peut pas être montée directement. C'est une partition système spéciale et ce comportement est normal.";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "Impossible d'éjecter « %@ » car l'un de ses volumes est occupé ou en cours d'utilisation.";
 "Failed to %@ “%@” because it is currently in use by another application." = "Impossible de %@ « %@ » car il est actuellement utilisé par une autre application.";
 "Failed to %@ “%@” because it is currently in use by “%@”." = "Impossible de %@ « %@ » car il est actuellement utilisé par « %@ ».";
 "An unknown error occurred while trying to %@ “%@”." = "Une erreur inconnue s'est produite lors de la tentative de %@ « %@ ».";
-"Enter the password to unlock “%@”" = "Saisissez le mot de passe pour déverrouiller « %@ »";
+"Enter the password to unlock “%@”" = "Entrez le mot de passe pour déverrouiller « %@ »";
 "Password" = "Mot de passe";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Pour permettre à MountMate de voir tous les types de disques et d'éviter les erreurs, veuillez accorder l'accès complet au disque.\n\nCliquez sur « Ouvrir les Réglages Système » pour accéder directement au bon panneau.";
 "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate n'a pas pu récupérer les informations sur les disques. Le système est peut-être occupé, un disque ne répond peut-être pas ou les autorisations sont incorrectes.";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "Impossible de lire les détails de stockage. Veuillez accorder à MountMate l'accès complet au disque ou les permissions « Fichiers et dossiers » dans Réglages Système > Confidentialité et sécurité.";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "Impossible d'enregistrer les réglages pour « %@ » car il n'a pas d'identifiant unique (UUID).";
 
-// MARK: - App Lifecycle & Loading
-//=============================================
+// Disk usage format
+"DiskUsageUsedFree" = "%@ utilisé / %@ (%@ libres)";
 
+// App Lifecycle
 "Loading Disks..." = "Chargement des disques...";
-"Restart Required" = "Redémarrage requis";
 "Please restart MountMate for the language change to take effect." = "Veuillez redémarrer MountMate pour que le changement de langue prenne effet.";
-"Restart Now" = "Redémarrer maintenant";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Pour utiliser les raccourcis clavier, veuillez accorder à MountMate l'accès d'accessibilité dans Réglages Système → Confidentialité et sécurité → Accessibilité.";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "Partages réseau";
+
+"Add Share" = "Ajouter un partage";
 "Add Network Share" = "Ajouter un partage réseau";
 "Edit Network Share" = "Modifier un partage réseau";
-"Server Address" = "Adresse du serveur";
-"Share Name/Path" = "Nom/chemin du partage";
-"Username" = "Nom d'utilisateur";
-"Password" = "Mot de passe";
-"Custom Mount Point" = "Point de montage personnalisé";
-"Mount at Login" = "Monter à l'ouverture de session";
 "MountMate can automatically mount these SMB shares at login." = "MountMate peut monter automatiquement ces partages SMB à l'ouverture de session.";
 "No Network Shares Configured" = "Aucun partage réseau configuré";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "Ajoutez vos partages réseau SMB ou NAS ici pour les monter automatiquement ou à la demande.";
+"Saved Network Shares" = "Partages réseau enregistrés";
+"Manually Connected Shares" = "Partages connectés manuellement";
+"Eject All Manually Connected Shares" = "Éjecter tous les partages connectés manuellement";
+"Auto-mount" = "Montage auto";
+"Auto-mounts at login" = "Monte automatiquement à l'ouverture de session";
+"Mount Share" = "Monter le partage";
+"Unmount Share" = "Démonter le partage";
+"Edit Share" = "Modifier le partage";
+"Delete Share" = "Supprimer le partage";
+"Remove" = "Retirer";
 "Mounted" = "Monté";
 "Not Mounted" = "Non monté";
 "Display Name" = "Nom d'affichage";
 "Connection" = "Connexion";
 "Credentials" = "Identifiants";
 "Options" = "Options";
+"Server Address" = "Adresse du serveur";
+"Share Name/Path" = "Nom/chemin du partage";
+"Username" = "Nom d'utilisateur";
+"Custom Mount Point" = "Point de montage personnalisé";
+"Mount at Login" = "Monter à l'ouverture de session";
 "Leave empty to use default location" = "Laissez vide pour utiliser l'emplacement par défaut";
-"Preview: %@" = "Aperçu : %@";
+"Optional (Defaults to share name)" = "Optionnel (Par défaut : nom du partage)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Optionnel (Invité)";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "Point de montage personnalisé…";
 "Use Custom Mount Point" = "Utiliser un point de montage personnalisé";
 "Folder Path" = "Chemin du dossier";
 "Custom Mount Point Path Prompt" = "/Volumes/MonDisque";
 "Choose Folder" = "Choisir un dossier…";
 "Choose" = "Choisir";
-"Reset" = "Réinitialiser";
+"Choose..." = "Choisir…";
+"Select custom mount directory" = "Sélectionnez le dossier de montage";
 "Default Path" = "Chemin par défaut";
 "Save" = "Enregistrer";
 "Create" = "Créer";
 "Use Folder" = "Utiliser ce dossier";
-"Custom Mount Point Empty Means Default" = "Laissez vide pour utiliser l'emplacement par défaut.";
 "Custom Mount Point System Helper" = "Laissez vide pour utiliser l'emplacement par défaut. L'enregistrement mettra à jour les règles système et pourra demander votre mot de passe administrateur une fois.";
 "Custom Mount Point Summary" = "Personnalisé : %@";
 "Create Folder Title" = "Créer un dossier ?";
@@ -169,8 +220,6 @@
 "Custom Mount Point Cannot Be Root" = "Le point de montage personnalisé ne peut pas être le dossier racine.";
 "Custom Mount Point In Use" = "Ce dossier est déjà utilisé par le volume monté « %@ ».";
 "Custom Mount Point Must Be Folder" = "Le point de montage personnalisé doit être un dossier.";
-"Custom Mount Point Prepare Fallback" = "MountMate n'a pas pu préparer le point de montage personnalisé.";
-"Custom Mount Point Prepare Error" = "MountMate n'a pas pu préparer le point de montage personnalisé.\n\nDétails :\n%@";
 "Custom Mount Point Inspect Error" = "MountMate n'a pas pu inspecter ce dossier.\n\nDétails :\n%@";
 "Custom Mount Point Create Error" = "MountMate n'a pas pu créer ce dossier.\n\nDétails :\n%@";
 "Custom Mount Point Requires UUID" = "Ce volume n'expose pas d'UUID stable, donc MountMate ne peut pas ajouter de règle de montage système pour celui-ci.";
@@ -178,54 +227,10 @@
 "Custom Mount Point System Conflict" = "Ce volume possède déjà une entrée /etc/fstab différente qui n'est pas gérée par MountMate.";
 "Custom Mount Point System Error" = "MountMate n'a pas pu mettre à jour la règle de montage système.";
 "Custom Mount Point System Save Error" = "MountMate n'a pas pu mettre à jour la règle de montage système.\n\nDétails :\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "Forcer l'éjection";
-"The disk is in use. Do you want to force eject it?" = "Le disque est en cours d'utilisation. Voulez-vous forcer son éjection ?";
-"This may result in data loss." = "Cela peut entraîner une perte de données.";
-"Remember password in Keychain" = "Mémoriser le mot de passe dans le Trousseau";
 
-// Chaînes supplémentaires découvertes dans les vues SwiftUI
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Tout démonter";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - Tout monter";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁体）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Pour utiliser les raccourcis clavier, accordez à MountMate l'accès Accessibilité dans Réglages Système → Confidentialité & Sécurité → Accessibilité.";
-
-"Volume: %@" = "Volume : %@";
-"Disk: %@" = "Disque : %@";
-"APFS Container • %@" = "Conteneur APFS • %@";
-
-"Settings" = "Paramètres";
-"Refresh Drives" = "Actualiser les disques";
-"Retry" = "Réessayer";
-"Auto-mounts at login" = "Monte automatiquement à l'ouverture de session";
-"Mount Now" = "Monter maintenant";
-"Edit" = "Modifier";
-"Delete" = "Supprimer";
-
-"Accessibility Permission Required" = "Permission Accessibilité requise";
-
-"Add Share" = "Ajouter un partage";
-
-"Optional (Defaults to share name)" = "Optionnel (Par défaut : nom du partage)";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "Optionnel (Invité)";
-
-// Chaînes restantes
-"MountMate" = "MountMate";
-"Expand All" = "Tout développer";
-"Collapse All" = "Tout réduire";
-"Try Again" = "Réessayer";
-"Action Failed" = "Action échouée";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ utilisé / %@ (%@ libres)";
+"Preview: %@" = "Aperçu : %@";

--- a/MountMate/Resources/ru.lproj/Localizable.strings
+++ b/MountMate/Resources/ru.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings (Russian)
 */
 
@@ -32,6 +32,8 @@
 
 "Unknown" = "Неизвестно";
 "Unmounted" = "Не смонтировано";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "Образ диска";
 
 
 // MARK: - Context Menus
@@ -47,23 +49,39 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "Настройки MountMate";
-
 // Tabs
 "General" = "Основные";
 "Management" = "Управление";
+"Network Shares" = "Сетевые ресурсы";
 
-// General Tab
-"Enable Keyboard Shortcuts" = "Включить сочетания клавиш";
+// Display Section
+"Display" = "Отображение";
 "Show Count in Menu Bar" = "Показывать количество в строке меню";
 "Show Internal Disks" = "Показывать внутренние диски";
+"Show Only Volumes" = "Показывать только томы";
+
+// Behavior Section
+"Behavior" = "Поведение";
 "Start MountMate at Login" = "Запускать MountMate при входе";
 "Block USB Auto-Mount" = "Блокировать автоподключение USB";
 "Unmount All Disks on Sleep" = "Отмонтировать все диски во время сна";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "Сочетания и язык";
+"Enable Keyboard Shortcuts" = "Включить сочетания клавиш";
+"Unmount All Volumes" = "Отмонтировать все томы";
+"Mount All Volumes" = "Смонтировать все томы";
 "Language" = "Язык";
+"English" = "Английский";
+"Français" = "Французский";
+"Українська" = "Украинский";
+"Русский" = "Русский";
+"Tiếng Việt" = "Вьетнамский";
+"中文（简体）" = "Китайский (упрощённый)";
+"中文（繁体）" = "Китайский (традиционный)";
 
 // About & Updates Section
-"About & Updates" = "О приложении и обновления";
+"About & Updates" = "О приложении и обновлениях";
 "Homepage" = "Домашняя страница";
 "Support Email" = "Электронная почта поддержки";
 "Donate" = "Пожертвовать";
@@ -78,7 +96,7 @@
 "Right-click a volume to protect it from 'Unmount All' and sleep actions." = "Щёлкните правой кнопкой на томе, чтобы защитить его от 'Отмонтировать все' и действий во время сна.";
 
 "Don't Auto-Mount This Volume" = "Не монтировать этот том автоматически";
-"Blocked from Auto-Mounting" = "Заблокировано от автоподключения";
+"Blocked from Auto-Mounting" = "Заблокированные от автоподключения";
 "No Volumes Blocked from Auto-Mounting" = "Нет томов, заблокированных от автоподключения";
 "Right-click a volume to prevent it from mounting automatically when connected." = "Щёлкните правой кнопкой на томе, чтобы запретить его автоматическое монтирование при подключении.";
 
@@ -91,8 +109,11 @@
 "Eject Failed" = "Не удалось извлечь";
 "Mount Failed" = "Не удалось смонтировать";
 "Unmount Failed" = "Не удалось отмонтировать";
-"\"%@\" is locked" = "«%@» заблокирован";
+"“%@” is locked" = "«%@» заблокирован";
 "Full Disk Access Recommended" = "Рекомендуется полный доступ к дискам";
+"Action Failed" = "Операция не удалась";
+"Accessibility Permission Required" = "Требуется разрешение на универсальный доступ";
+"Restart Required" = "Требуется перезапуск";
 
 // Buttons
 "OK" = "OK";
@@ -100,6 +121,14 @@
 "Cancel" = "Отмена";
 "Open System Settings" = "Открыть системные настройки";
 "Later" = "Позже";
+"Retry" = "Повторить";
+"Try Again" = "Попробовать снова";
+"Force Eject" = "Принудительно извлечь";
+"Force Unmount" = "Принудительно отмонтировать";
+"Remember password in Keychain" = "Запомнить пароль в Keychain";
+"Restart Now" = "Перезапустить сейчас";
+"MountMate" = "MountMate";
+"Details" = "Детали";
 
 // Verbs for error messages
 "unmount" = "отмонтировать";
@@ -107,52 +136,101 @@
 "mount" = "смонтировать";
 
 // Error Messages & Formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nПредоставьте MountMate полный доступ к дискам в Системных настройках > Конфиденциальность и безопасность.";
-"The \"EFI\" partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "Раздел «EFI» нельзя смонтировать напрямую. Это специальный системный раздел, и такое поведение является нормальным.";
-"Failed to eject \"%@\" because one of its volumes is busy or in use." = "Не удалось извлечь «%@», поскольку один из его томов занят или используется.";
-"Failed to %@ \"%@\" because it is currently in use by another application." = "Не удалось %@ «%@», поскольку он сейчас используется другой программой.";
-"Failed to %@ \"%@\" because it is currently in use by \"%@\"." = "Не удалось %@ «%@», поскольку он сейчас используется «%@».";
-"An unknown error occurred while trying to %@ \"%@\"." = "Во время попытки %@ «%@» произошла неизвестная ошибка.";
-"Enter the password to unlock \"%@\"" = "Введите пароль, чтобы разблокировать «%@»";
+"The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "Раздел «EFI» нельзя смонтировать напрямую. Это специальный системный раздел, и такое поведение является нормальным.";
+"Failed to eject “%@” because one of its volumes is busy or in use." = "Не удалось извлечь «%@», потому что один из его томов занят или используется.";
+"Failed to %@ “%@” because it is currently in use by another application." = "Не удалось %@ «%@», потому что он используется другим приложением.";
+"Failed to %@ “%@” because it is currently in use by “%@”." = "Не удалось %@ «%@», потому что он используется приложением «%@».";
+"An unknown error occurred while trying to %@ “%@”." = "Произошла неизвестная ошибка при попытке %@ «%@».";
+"Enter the password to unlock “%@”" = "Введите пароль, чтобы разблокировать «%@»";
 "Password" = "Пароль";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Чтобы убедиться, что MountMate видит все типы дисков и предотвращает ошибки, предоставьте полный доступ к дискам.\n\nНажмите «Открыть системные настройки», чтобы перейти к соответствующей панели.";
 "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate не смог получить информацию о дисках. Система может быть занята, диск может не отвечать, или права доступа могут быть неправильными.";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "Не удалось прочитать данные о хранилище. Предоставьте MountMate полный доступ к дискам или разрешения «Файлы и папки» в Системных настройках > Конфиденциальность и безопасность.";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "Не удалось сохранить настройки для «%@», потому что у него нет уникального идентификатора (UUID).";
 
-// MARK: - App Lifecycle & Loading
-//=============================================
+// Disk usage format
+"DiskUsageUsedFree" = "%@ использовано / %@ (%@ свободно)";
 
+// App Lifecycle
 "Loading Disks..." = "Загрузка дисков...";
-"Restart Required" = "Требуется перезапуск";
 "Please restart MountMate for the language change to take effect." = "Пожалуйста, перезапустите MountMate, чтобы изменения языка вступили в силу.";
-"Restart Now" = "Перезапустить сейчас";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Чтобы использовать сочетания клавиш, предоставьте MountMate доступ к универсальному доступу в Системных настройках → Конфиденциальность и безопасность → Специальные возможности.";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "Сетевые ресурсы";
+
 "Add Share" = "Добавить ресурс";
 "Add Network Share" = "Добавить сетевой ресурс";
 "Edit Network Share" = "Редактировать сетевой ресурс";
-"Server Address" = "Адрес сервера";
-"Share Name/Path" = "Название/путь ресурса";
-"Username" = "Имя пользователя";
-"Password" = "Пароль";
-"Custom Mount Point" = "Пользовательская точка подключения";
-"Mount at Login" = "Монтировать при входе";
 "MountMate can automatically mount these SMB shares at login." = "MountMate может автоматически монтировать эти SMB-ресурсы при входе.";
 "No Network Shares Configured" = "Сетевые ресурсы не настроены";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "Добавляйте сюда ваши SMB или NAS сетевые ресурсы для автоматического или по запросу монтирования.";
+"Saved Network Shares" = "Сохранённые сетевые ресурсы";
+"Manually Connected Shares" = "Ручные подключённые ресурсы";
+"Eject All Manually Connected Shares" = "Извлечь все ручные подключённые ресурсы";
+"Auto-mount" = "Автомонт";
+"Auto-mounts at login" = "Автоматически монтируется при входе";
+"Mount Share" = "Смонтировать";
+"Unmount Share" = "Отмонтировать";
+"Edit Share" = "Редактировать";
+"Delete Share" = "Удалить";
+"Remove" = "Удалить";
 "Mounted" = "Смонтировано";
 "Not Mounted" = "Не смонтировано";
 "Display Name" = "Отображаемое имя";
 "Connection" = "Подключение";
 "Credentials" = "Учётные данные";
 "Options" = "Параметры";
+"Server Address" = "Адрес сервера";
+"Share Name/Path" = "Название/путь ресурса";
+"Username" = "Имя пользователя";
+"Custom Mount Point" = "Пользовательская точка подключения";
+"Mount at Login" = "Монтировать при входе";
 "Leave empty to use default location" = "Оставьте пустым, чтобы использовать место по умолчанию";
-"Preview: %@" = "Предварительный просмотр: %@";
+"Optional (Defaults to share name)" = "Необязательно (По умолчанию - имя ресурса)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Необязательно (Гость)";
 
-// MARK: - Force Eject
+
+// MARK: - Custom Mount Point
 //=============================================
-"Force Eject" = "Принудительно извлечь";
-"The disk is in use. Do you want to force eject it?" = "Диск используется. Желаете принудительно извлечь его?";
-"This may result in data loss." = "Это может привести к потере данных.";
-"Remember password in Keychain" = "Запомнить пароль в Keychain";
-"Custom Mount Point System Error" = "MountMate не удалось обновить системное правило монтирования.";
+
+"Custom Mount Point Menu" = "Пользовательская точка монтирования…";
+"Use Custom Mount Point" = "Использовать пользовательскую точку монтирования";
+"Folder Path" = "Путь к папке";
+"Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
+"Choose Folder" = "Выбрать…";
+"Choose" = "Выбрать";
+"Choose..." = "Выбрать…";
+"Select custom mount directory" = "Выберите папку для монтирования";
+"Default Path" = "Путь по умолчанию";
+"Save" = "Сохранить";
+"Create" = "Создать";
+"Use Folder" = "Использовать папку";
+"Custom Mount Point System Helper" = "Оставьте поле пустым, чтобы использовать стандартное место монтирования macOS. Сохранение обновляет системное правило монтирования и может один раз запросить пароль администратора.";
+"Custom Mount Point Summary" = "Пользовательская: %@";
+"Create Folder Title" = "Создать папку?";
+"Create Folder Message" = "Эта папка ещё не существует. MountMate может создать её перед сохранением.";
+"Folder Not Empty Title" = "Папка не пуста";
+"Folder Not Empty Message" = "Выбранная папка уже содержит файлы. Монтирование здесь может временно скрыть их, пока том смонтирован.";
+"Custom Mount Point Empty Path" = "Введите путь к папке.";
+"Custom Mount Point Must Be Absolute" = "Пользовательская точка монтирования должна быть абсолютным путём.";
+"Custom Mount Point Cannot Be Root" = "Пользовательская точка монтирования не может быть корневой папкой.";
+"Custom Mount Point In Use" = "Эта папка уже используется смонтированным томом «%@».";
+"Custom Mount Point Must Be Folder" = "Пользовательская точка монтирования должна быть папкой.";
+"Custom Mount Point Inspect Error" = "MountMate не смог проверить эту папку.\n\nДетали:\n%@";
+"Custom Mount Point Create Error" = "MountMate не смог создать эту папку.\n\nДетали:\n%@";
+"Custom Mount Point Requires UUID" = "Этот том не имеет стабильного UUID, поэтому MountMate не может добавить для него системное правило монтирования.";
+"Custom Mount Point Unsupported File System" = "MountMate не смог определить правильный тип файловой системы для системного правила монтирования этого тома.";
+"Custom Mount Point System Conflict" = "Для этого тома уже существует другая запись /etc/fstab, которой MountMate не управляет.";
+"Custom Mount Point System Error" = "MountMate не смог обновить системное правило монтирования.";
+"Custom Mount Point System Save Error" = "MountMate не смог обновить системное правило монтирования.\n\nДетали:\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
+
+
+// MARK: - Connection String Preview
+//=============================================
+
+"Preview: %@" = "Предварительный просмотр: %@";

--- a/MountMate/Resources/uk.lproj/Localizable.strings
+++ b/MountMate/Resources/uk.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 //=============================================
 
 "No Drives Found" = "Диски не знайдені";
-"Connect a USB drive, SD card, or mount a disk image to see it here." = "Підключіть USB-накопичувач, SD-карту або змонтуйте образ диска, щоб він з’явився тут.";
+"Connect a USB drive, SD card, or mount a disk image to see it here." = "Підключіть USB-накопичувач, SD-карту або змонтуйте образ диска, щоб він з'явився тут.";
 "Internal Disks" = "Внутрішні диски";
 "External Disks" = "Зовнішні диски";
 "Disk Images" = "Образи дисків";
@@ -32,6 +32,8 @@
 
 "Unknown" = "Невідомо";
 "Unmounted" = "Не змонтовано";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "Образ диска";
 
 
 // MARK: - Context Menus
@@ -39,35 +41,51 @@
 
 "Ignore This Disk" = "Ігнорувати цей диск";
 "Ignore This Volume" = "Ігнорувати цей том";
-"Protect from 'Unmount All'" = "Захистити від 'Відмонтувати всі'";
-"Unprotect from 'Unmount All'" = "Прибрати захист від 'Відмонтувати всі'";
+"Protect from 'Unmount All'" = "Захистити від 'Відмонтувати всі томи'";
+"Unprotect from 'Unmount All'" = "Прибрати захист від 'Відмонтувати всі томи'";
 "Open in Finder" = "Відкрити у Finder";
 
 
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "Налаштування MountMate";
-
 // Tabs
 "General" = "Загальні";
 "Management" = "Керування";
+"Network Shares" = "Мережеві ресурси";
 
-// General Tab
-"Enable Keyboard Shortcuts" = "Увімкнути клавіатурні скорочення";
+// Display Section
+"Display" = "Відображення";
 "Show Count in Menu Bar" = "Показувати кількість у рядку меню";
 "Show Internal Disks" = "Показувати внутрішні диски";
+"Show Only Volumes" = "Показувати лише томи";
+
+// Behavior Section
+"Behavior" = "Поведінка";
 "Start MountMate at Login" = "Запускати MountMate при вході";
 "Block USB Auto-Mount" = "Блокувати автопідключення USB";
 "Unmount All Disks on Sleep" = "Відмонтувати всі диски під час сну";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "Скорочення та мова";
+"Enable Keyboard Shortcuts" = "Увімкнути клавіатурні скорочення";
+"Unmount All Volumes" = "Відмонтувати всі томи";
+"Mount All Volumes" = "Підключити всі томи";
 "Language" = "Мова";
+"English" = "Англійська";
+"Français" = "Французька";
+"Українська" = "Українська";
+"Русский" = "Російська";
+"Tiếng Việt" = "В'єтнамська";
+"中文（简体）" = "Китайська (спрощена)";
+"中文（繁体）" = "Китайська (традиційна)";
 
 // About & Updates Section
+"About & Updates" = "Про програму та оновлення";
 "Homepage" = "Домашня сторінка";
 "Support Email" = "Електронна пошта підтримки";
 "Donate" = "Пожертвувати";
 "Check for Updates..." = "Перевірити оновлення...";
-"About & Updates" = "Про програму та оновлення";
 
 // Management Tab
 "Ignored Volumes" = "Ігноровані томи";
@@ -75,7 +93,7 @@
 "Right-click a volume to ignore it. Useful for system partitions like 'EFI' that you don't need to manage." = "Клацніть правою кнопкою на томі, щоб ігнорувати його. Корисно для системних розділів, таких як 'EFI', якими не потрібно керувати.";
 "Protected Volumes" = "Захищені томи";
 "No Protected Volumes" = "Немає захищених томів";
-"Right-click a volume to protect it from 'Unmount All' and sleep actions." = "Клацніть правою кнопкою на томі, щоб захистити його від 'Відмонтувати всі' та дій під час сну.";
+"Right-click a volume to protect it from 'Unmount All' and sleep actions." = "Клацніть правою кнопкою на томі, щоб захистити його від 'Відмонтувати всі томи' та дій під час сну.";
 
 "Don't Auto-Mount This Volume" = "Не монтувати цей том автоматично";
 "Blocked from Auto-Mounting" = "Заблоковано від автопідключення";
@@ -93,6 +111,9 @@
 "Unmount Failed" = "Не вдалося відмонтувати";
 "“%@” is locked" = "«%@» заблоковано";
 "Full Disk Access Recommended" = "Рекомендується повний доступ до дисків";
+"Action Failed" = "Операція не вдалася";
+"Accessibility Permission Required" = "Потрібен дозвіл доступності";
+"Restart Required" = "Потрібно перезапустити";
 
 // Buttons
 "OK" = "OK";
@@ -100,6 +121,14 @@
 "Cancel" = "Скасувати";
 "Open System Settings" = "Відкрити системні налаштування";
 "Later" = "Пізніше";
+"Retry" = "Повторити";
+"Try Again" = "Спробувати знову";
+"Force Eject" = "Примусово вийняти";
+"Force Unmount" = "Примусово відмонтувати";
+"Remember password in Keychain" = "Запам'ятати пароль у Keychain";
+"Restart Now" = "Перезапустити зараз";
+"MountMate" = "MountMate";
+"Details" = "Деталі";
 
 // Verbs for error messages
 "unmount" = "відмонтувати";
@@ -107,77 +136,90 @@
 "mount" = "змонтувати";
 
 // Error Messages & Formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nНадайте MountMate повний доступ до дисків у Системних налаштуваннях > Конфіденційність і безпека.";
 "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "Розділ «EFI» не можна змонтувати безпосередньо. Це спеціальний системний розділ, і така поведінка є нормальною.";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "Не вдалося вийняти «%@», оскільки один із його томів зайнятий або використовується.";
-"Failed to %@ “%@” because it is currently in use by another application." = "Не вдалося %@ «%@», оскільки він зараз використовується іншою програмою.";
-"Failed to %@ “%@” because it is currently in use by “%@”." = "Не вдалося %@ «%@», оскільки він зараз використовується «%@».";
-"An unknown error occurred while trying to %@ “%@”." = "Під час спроби %@ «%@» сталася невідома помилка.";
+"Failed to %@ “%@” because it is currently in use by another application." = "Не вдалося %@ «%@», оскільки його використовує інший застосунок.";
+"Failed to %@ “%@” because it is currently in use by “%@”." = "Не вдалося %@ «%@», оскільки його використовує «%@».";
+"An unknown error occurred while trying to %@ “%@”." = "Сталася невідома помилка під час спроби %@ «%@».";
 "Enter the password to unlock “%@”" = "Введіть пароль, щоб розблокувати «%@»";
 "Password" = "Пароль";
-"To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Щоб переконатися, що MountMate бачить усі типи дисків та уникнути помилок, надайте повний доступ до дисків.\n\nНатисніть «Відкрити системні налаштування», щоб перейти до відповідної панелі.";
+"To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Щоб переконатися, що MountMate бачить усі типи дисків та уникне помилок, надайте повний доступ до дисків.\n\nНатисніть «Відкрити системні налаштування», щоб перейти до відповідної панелі.";
 "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate не зміг отримати інформацію про диски. Система може бути зайнята, диск може не відповідати, або права доступу можуть бути неправильними.";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "Не вдалося прочитати дані про зберігання. Надайте MountMate повний доступ до дисків або дозволи «Файли і папки» в Системних налаштуваннях > Конфіденційність і безпека.";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "Не вдалося зберегти налаштування для «%@», оскільки він не має унікального ідентифікатора (UUID).";
 
-// MARK: - App Lifecycle & Loading
-//=============================================
+// Disk usage format
+"DiskUsageUsedFree" = "%@ використано / %@ (%@ вільно)";
 
+// App Lifecycle
 "Loading Disks..." = "Завантаження дисків...";
-"Restart Required" = "Потрібно перезапустити";
-"Please restart MountMate for the language change to take effect." = "Будь ласка, перезапустіть MountMate, щоб зміни мови набрали чинності.";
-"Restart Now" = "Перезапустити зараз";
+"Please restart MountMate for the language change to take effect." = "Будь ласка, перезапустіть MountMate, щоб зміни мови набрали силу.";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Щоб використовувати клавіатурні скорочення, надайте MountMate доступ до спеціальних можливостей у Системних налаштуваннях → Конфіденційність і безпека → Спеціальні можливості.";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "Мережеві шари";
+
 "Add Share" = "Додати ресурс";
 "Add Network Share" = "Додати мережевий ресурс";
 "Edit Network Share" = "Редагувати мережевий ресурс";
-"Server Address" = "Адреса сервера";
-"Share Name/Path" = "Назва/шлях ресурсу";
-"Username" = "Ім'я користувача";
-"Password" = "Пароль";
-"Custom Mount Point" = "Користувацька точка підключення";
-"Mount at Login" = "Монтувати при вході";
 "MountMate can automatically mount these SMB shares at login." = "MountMate може автоматично монтувати ці SMB-ресурси під час входу.";
 "No Network Shares Configured" = "Мережеві ресурси не налаштовані";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "Додавайте ваші SMB або NAS мережеві ресурси сюди для автоматичного або за запитом монтування.";
+"Saved Network Shares" = "Збережені мережеві ресурси";
+"Manually Connected Shares" = "Ручні підключені ресурси";
+"Eject All Manually Connected Shares" = "Вийняти всі ручні підключені ресурси";
+"Auto-mount" = "Автомонтування";
+"Auto-mounts at login" = "Автоматично монтується під час входу";
+"Mount Share" = "Підключити";
+"Unmount Share" = "Відмонтувати";
+"Edit Share" = "Редагувати";
+"Delete Share" = "Видалити";
+"Remove" = "Видалити";
 "Mounted" = "Змонтовано";
 "Not Mounted" = "Не змонтовано";
 "Display Name" = "Відображуване ім'я";
 "Connection" = "Підключення";
 "Credentials" = "Облікові дані";
 "Options" = "Параметри";
+"Server Address" = "Адреса сервера";
+"Share Name/Path" = "Назва/шлях ресурсу";
+"Username" = "Ім'я користувача";
+"Custom Mount Point" = "Власна точка підключення";
+"Mount at Login" = "Монтувати при вході";
 "Leave empty to use default location" = "Залиште порожнім, щоб використовувати типове місце";
-"Preview: %@" = "Попередній перегляд: %@";
+"Optional (Defaults to share name)" = "Необов’язково (За замовчуванням — ім'я ресурсу)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Необов’язково (Гість)";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "Власна точка монтування…";
 "Use Custom Mount Point" = "Використовувати власну точку монтування";
 "Folder Path" = "Шлях до теки";
 "Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
 "Choose Folder" = "Вибрати…";
 "Choose" = "Вибрати";
-"Reset" = "Скинути";
+"Choose..." = "Вибрати…";
+"Select custom mount directory" = "Виберіть папку для монтування";
 "Default Path" = "Типовий шлях";
 "Save" = "Зберегти";
 "Create" = "Створити";
 "Use Folder" = "Використати теку";
-"Custom Mount Point Help" = "Вимкніть це, щоб використовувати стандартне місце монтування macOS.";
-"Custom Mount Point Empty Means Default" = "Залиште поле порожнім, щоб використовувати стандартне місце монтування macOS.";
 "Custom Mount Point System Helper" = "Залиште поле порожнім, щоб використовувати стандартне місце монтування macOS. Збереження оновлює системне правило монтування і може один раз попросити пароль адміністратора.";
 "Custom Mount Point Summary" = "Власна: %@";
-"Create Folder Title" = "Створити теку?";
+"Create Folder Title" = "Створити папку?";
 "Create Folder Message" = "Ця тека ще не існує. MountMate може створити її перед збереженням.";
 "Folder Not Empty Title" = "Тека не порожня";
-"Folder Not Empty Message" = "Вибрана тека вже містить файли. Монтування тут може тимчасово приховати їх, поки том змонтований.";
+"Folder Not Empty Message" = "Вибрана тека вже містить файли. Монтування тут може тимчасово приховати їх, поки том змонтовано.";
 "Custom Mount Point Empty Path" = "Введіть шлях до теки.";
 "Custom Mount Point Must Be Absolute" = "Власна точка монтування повинна бути абсолютним шляхом.";
 "Custom Mount Point Cannot Be Root" = "Власна точка монтування не може бути кореневою текою.";
 "Custom Mount Point In Use" = "Ця тека вже використовується змонтованим томом «%@».";
 "Custom Mount Point Must Be Folder" = "Власна точка монтування повинна бути текою.";
-"Custom Mount Point Prepare Fallback" = "MountMate не зміг підготувати власну точку монтування.";
-"Custom Mount Point Prepare Error" = "MountMate не зміг підготувати власну точку монтування.\n\nДеталі:\n%@";
 "Custom Mount Point Inspect Error" = "MountMate не зміг перевірити цю теку.\n\nДеталі:\n%@";
 "Custom Mount Point Create Error" = "MountMate не зміг створити цю теку.\n\nДеталі:\n%@";
 "Custom Mount Point Requires UUID" = "Цей том не має стабільного UUID, тому MountMate не може додати для нього системне правило монтування.";
@@ -185,54 +227,10 @@
 "Custom Mount Point System Conflict" = "Для цього тому вже існує інший запис /etc/fstab, яким MountMate не керує.";
 "Custom Mount Point System Error" = "MountMate не зміг оновити системне правило монтування.";
 "Custom Mount Point System Save Error" = "MountMate не зміг оновити системне правило монтування.\n\nДеталі:\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "Примусово вийняти";
-"The disk is in use. Do you want to force eject it?" = "Диск використовується. Бажаєте примусово вийняти його?";
-"This may result in data loss." = "Це може призвести до втрати даних.";
-"Remember password in Keychain" = "Запам'ятати пароль у Keychain";
 
-// Додаткові рядки, знайдені у SwiftUI
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Відмонтувати всі томи";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - Підключити всі томи";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁体）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Щоб використовувати ярлики клавіатури, надайте MountMate доступ Accessibility у Системних налаштуваннях → Конфіденційність і безпека → Доступність.";
-
-"Volume: %@" = "Том: %@";
-"Disk: %@" = "Диск: %@";
-"APFS Container • %@" = "Контейнер APFS • %@";
-
-"Settings" = "Налаштування";
-"Refresh Drives" = "Оновити диски";
-"Retry" = "Повторити";
-"Auto-mounts at login" = "Автоматично монтується при вході";
-"Mount Now" = "Підключити зараз";
-"Edit" = "Редагувати";
-"Delete" = "Видалити";
-
-"Accessibility Permission Required" = "Потрібен дозвіл доступності";
-
-"Add Share" = "Додати мережевий ресурс";
-
-"Optional (Defaults to share name)" = "Необов'язково (За замовчуванням - ім'я ресурсу)";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "Необов'язково (Гість)";
-
-// Решта рядків
-"MountMate" = "MountMate";
-"Expand All" = "Розгорнути все";
-"Collapse All" = "Згорнути все";
-"Try Again" = "Спробувати знову";
-"Action Failed" = "Операція не вдалася";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ використано / %@ (%@ вільно)";
+"Preview: %@" = "Попередній перегляд: %@";

--- a/MountMate/Resources/vi.lproj/Localizable.strings
+++ b/MountMate/Resources/vi.lproj/Localizable.strings
@@ -18,10 +18,10 @@
 
 "Expand All" = "Mở rộng tất cả";
 "Collapse All" = "Thu gọn tất cả";
-"Unmount All" = "Tháo tất cả phân vùng người dùng";
+"Unmount All" = "Tháo tất cả phân vùng";
 "Settings" = "Cài đặt";
 "Refresh Drives" = "Làm mới ổ đĩa";
-"Eject" = "Đẩy ra an toàn";
+"Eject" = "Đẩy ra";
 "Mount" = "Gắn";
 "Unmount" = "Tháo";
 "Quit MountMate" = "Thoát MountMate";
@@ -32,6 +32,8 @@
 
 "Unknown" = "Không rõ";
 "Unmounted" = "Chưa gắn";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "Ảnh đĩa";
 
 
 // MARK: - Context Menus
@@ -47,27 +49,43 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "Cài đặt MountMate";
-
 // Tabs
 "General" = "Chung";
 "Management" = "Quản lý";
+"Network Shares" = "Chia sẻ Mạng";
 
-// General Tab
+// Display Section
+"Display" = "Hiển thị";
 "Show Count in Menu Bar" = "Hiển thị số lượng trên thanh menu";
 "Show Internal Disks" = "Hiển thị ổ đĩa trong";
+"Show Only Volumes" = "Chỉ hiển thị phân vùng";
+
+// Behavior Section
+"Behavior" = "Hành vi";
 "Start MountMate at Login" = "Khởi động cùng máy";
 "Block USB Auto-Mount" = "Chặn tự động gắn USB";
 "Unmount All Disks on Sleep" = "Tháo tất cả ổ đĩa khi ngủ";
-"Language" = "Ngôn ngữ";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "Phím tắt & Ngôn ngữ";
 "Enable Keyboard Shortcuts" = "Bật phím tắt";
+"Unmount All Volumes" = "Tháo tất cả phân vùng";
+"Mount All Volumes" = "Gắn tất cả phân vùng";
+"Language" = "Ngôn ngữ";
+"English" = "Tiếng Anh";
+"Français" = "Tiếng Pháp";
+"Українська" = "Tiếng Ukraina";
+"Русский" = "Tiếng Nga";
+"Tiếng Việt" = "Tiếng Việt";
+"中文（简体）" = "Tiếng Trung (Giản thể)";
+"中文（繁体）" = "Tiếng Trung (Phồn thể)";
 
 // About & Updates Section
+"About & Updates" = "Giới thiệu & Cập nhật";
 "Homepage" = "Trang chủ";
 "Support Email" = "Email hỗ trợ";
 "Donate" = "Ủng hộ";
 "Check for Updates..." = "Kiểm tra cập nhật...";
-"About & Updates" = "Giới thiệu & Cập nhật";
 
 // Management Tab
 "Ignored Volumes" = "Phân vùng bị bỏ qua";
@@ -93,6 +111,9 @@
 "Unmount Failed" = "Tháo thất bại";
 "“%@” is locked" = "“%@” đã bị khoá";
 "Full Disk Access Recommended" = "Nên cấp quyền Truy cập Toàn bộ Đĩa";
+"Action Failed" = "Thao tác thất bại";
+"Accessibility Permission Required" = "Cần quyền Trợ năng";
+"Restart Required" = "Cần khởi động lại";
 
 // Buttons
 "OK" = "OK";
@@ -100,6 +121,14 @@
 "Cancel" = "Huỷ";
 "Open System Settings" = "Mở Cài đặt Hệ thống";
 "Later" = "Để sau";
+"Retry" = "Thử lại";
+"Try Again" = "Thử lại";
+"Force Eject" = "Buộc Đẩy ra";
+"Force Unmount" = "Buộc tháo";
+"Remember password in Keychain" = "Ghi nhớ mật khẩu trong Keychain";
+"Restart Now" = "Khởi động lại ngay";
+"MountMate" = "MountMate";
+"Details" = "Chi tiết";
 
 // Verbs for error messages
 "unmount" = "tháo";
@@ -107,7 +136,6 @@
 "mount" = "gắn";
 
 // Error Messages & Formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\nVui lòng cấp cho MountMate quyền 'Truy cập Toàn bộ Đĩa' trong Cài đặt Hệ thống > Quyền riêng tư & Bảo mật.";
 "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "Không thể gắn trực tiếp phân vùng “EFI”. Đây là một phân vùng hệ thống đặc biệt và hành vi này là bình thường.";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "Không thể đẩy ra “%@” vì một trong các phân vùng của nó đang bận hoặc đang được sử dụng.";
 "Failed to %@ “%@” because it is currently in use by another application." = "Không thể %@ “%@” vì đang được sử dụng bởi một ứng dụng khác.";
@@ -117,54 +145,70 @@
 "Password" = "Mật khẩu";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "Để đảm bảo MountMate có thể thấy tất cả các loại ổ đĩa và ngăn ngừa lỗi, vui lòng cấp quyền Truy cập Toàn bộ Đĩa.\n\nNhấp vào 'Mở Cài đặt Hệ thống' để được đưa đến bảng điều khiển chính xác.";
 "MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate không thể lấy thông tin ổ đĩa. Hệ thống có thể đang bận, một ổ đĩa không phản hồi, hoặc quyền truy cập có thể không chính xác.";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "Không thể đọc thông tin lưu trữ. Vui lòng cấp cho MountMate quyền 'Truy cập Toàn bộ Đĩa' hoặc 'Tệp và Thư mục' trong Cài đặt Hệ thống > Quyền riêng tư & Bảo mật.";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "Không thể lưu cài đặt cho “%@” vì nó không có mã định danh duy nhất (UUID).";
 
-// MARK: - App Lifecycle & Loading
-//=============================================
+// Disk usage format
+"DiskUsageUsedFree" = "%@ đã sử dụng / %@ (%@ còn trống)";
 
+// App Lifecycle
 "Loading Disks..." = "Đang tải ổ đĩa...";
-"Restart Required" = "Cần khởi động lại";
 "Please restart MountMate for the language change to take effect." = "Vui lòng khởi động lại MountMate để thay đổi ngôn ngữ có hiệu lực.";
-"Restart Now" = "Khởi động lại ngay";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Để sử dụng phím tắt, vui lòng cấp MountMate quyền Accessibility trong Cài đặt Hệ thống → Quyền riêng tư & Bảo mật → Trợ năng.";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "Chia sẻ Mạng";
-"Add Share" = "Thêm Chia sẻ";
+
+"Add Share" = "Thêm chia sẻ";
 "Add Network Share" = "Thêm Chia sẻ Mạng";
 "Edit Network Share" = "Sửa Chia sẻ Mạng";
-"Server Address" = "Địa chỉ Máy chủ";
-"Share Name/Path" = "Tên/Đường dẫn Chia sẻ";
-"Username" = "Tên đăng nhập";
-"Password" = "Mật khẩu";
-"Custom Mount Point" = "Điểm Gắn Tùy chỉnh";
-"Mount at Login" = "Gắn khi Đăng nhập";
 "MountMate can automatically mount these SMB shares at login." = "MountMate có thể tự động gắn các chia sẻ SMB này khi đăng nhập.";
 "No Network Shares Configured" = "Chưa cấu hình Chia sẻ Mạng";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "Thêm chia sẻ mạng SMB hoặc NAS của bạn vào đây để gắn tự động hoặc theo yêu cầu.";
+"Saved Network Shares" = "Chia sẻ mạng đã lưu";
+"Manually Connected Shares" = "Chia sẻ kết nối thủ công";
+"Eject All Manually Connected Shares" = "Đẩy ra tất cả chia sẻ kết nối thủ công";
+"Auto-mount" = "Tự động gắn";
+"Auto-mounts at login" = "Tự động gắn khi đăng nhập";
+"Mount Share" = "Gắn chia sẻ";
+"Unmount Share" = "Tháo chia sẻ";
+"Edit Share" = "Sửa chia sẻ";
+"Delete Share" = "Xóa chia sẻ";
+"Remove" = "Xóa";
 "Mounted" = "Đã gắn";
 "Not Mounted" = "Chưa gắn";
 "Display Name" = "Tên Hiển thị";
 "Connection" = "Kết nối";
 "Credentials" = "Thông tin xác thực";
 "Options" = "Tùy chọn";
+"Server Address" = "Địa chỉ Máy chủ";
+"Share Name/Path" = "Tên/Đường dẫn Chia sẻ";
+"Username" = "Tên đăng nhập";
+"Custom Mount Point" = "Điểm Gắn Tùy chỉnh";
+"Mount at Login" = "Gắn khi Đăng nhập";
 "Leave empty to use default location" = "Để trống để dùng vị trí mặc định";
-"Preview: %@" = "Xem trước: %@";
+"Optional (Defaults to share name)" = "Tùy chọn (Mặc định: tên chia sẻ)";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "Tùy chọn (Khách)";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "Điểm gắn tùy chỉnh…";
 "Use Custom Mount Point" = "Dùng điểm gắn tùy chỉnh";
 "Folder Path" = "Đường dẫn thư mục";
 "Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
 "Choose Folder" = "Chọn…";
 "Choose" = "Chọn";
-"Reset" = "Đặt lại";
+"Choose..." = "Chọn…";
+"Select custom mount directory" = "Chọn thư mục gắn";
 "Default Path" = "Đường dẫn mặc định";
 "Save" = "Lưu";
 "Create" = "Tạo";
 "Use Folder" = "Dùng thư mục";
-"Custom Mount Point Help" = "Tắt tùy chọn này để dùng vị trí gắn mặc định của macOS.";
-"Custom Mount Point Empty Means Default" = "Để trống để dùng vị trí gắn mặc định của macOS.";
 "Custom Mount Point System Helper" = "Để trống để dùng vị trí gắn mặc định của macOS. Khi lưu, quy tắc gắn hệ thống sẽ được cập nhật và có thể hỏi mật khẩu quản trị một lần.";
 "Custom Mount Point Summary" = "Tùy chỉnh: %@";
 "Create Folder Title" = "Tạo thư mục?";
@@ -176,8 +220,6 @@
 "Custom Mount Point Cannot Be Root" = "Điểm gắn tùy chỉnh không được là thư mục gốc.";
 "Custom Mount Point In Use" = "Thư mục này đang được dùng bởi phân vùng đã gắn “%@”.";
 "Custom Mount Point Must Be Folder" = "Điểm gắn tùy chỉnh phải là một thư mục.";
-"Custom Mount Point Prepare Fallback" = "MountMate không thể chuẩn bị điểm gắn tùy chỉnh.";
-"Custom Mount Point Prepare Error" = "MountMate không thể chuẩn bị điểm gắn tùy chỉnh.\n\nChi tiết:\n%@";
 "Custom Mount Point Inspect Error" = "MountMate không thể kiểm tra thư mục này.\n\nChi tiết:\n%@";
 "Custom Mount Point Create Error" = "MountMate không thể tạo thư mục này.\n\nChi tiết:\n%@";
 "Custom Mount Point Requires UUID" = "Ổ này không cung cấp UUID ổn định nên MountMate không thể thêm quy tắc gắn hệ thống cho nó.";
@@ -185,54 +227,10 @@
 "Custom Mount Point System Conflict" = "Ổ này đã có một mục /etc/fstab khác không do MountMate quản lý.";
 "Custom Mount Point System Error" = "MountMate không thể cập nhật quy tắc gắn hệ thống.";
 "Custom Mount Point System Save Error" = "MountMate không thể cập nhật quy tắc gắn hệ thống.\n\nChi tiết:\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "Buộc Đẩy ra";
-"The disk is in use. Do you want to force eject it?" = "Ổ đĩa đang được sử dụng. Bạn có muốn buộc đẩy ra không?";
-"This may result in data loss." = "Việc này có thể dẫn đến mất dữ liệu.";
-"Remember password in Keychain" = "Ghi nhớ mật khẩu trong Keychain";
 
-// Các chuỗi còn lại
-"MountMate" = "MountMate";
-"Expand All" = "Mở rộng tất cả";
-"Collapse All" = "Thu gọn tất cả";
-"Try Again" = "Thử lại";
-"Action Failed" = "Thao tác thất bại";
-
-// Chuỗi bổ sung được phát hiện trong SwiftUI
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - Tháo tất cả phân vùng";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - Gắn tất cả phân vùng";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁体）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "Để sử dụng phím tắt, vui lòng cấp MountMate quyền Accessibility trong Cài đặt Hệ thống → Quyền riêng tư & Bảo mật → Trợ năng.";
-
-"Volume: %@" = "Phân vùng: %@";
-"Disk: %@" = "Ổ đĩa: %@";
-"APFS Container • %@" = "Bộ chứa APFS • %@";
-
-"Settings" = "Cài đặt";
-"Refresh Drives" = "Làm mới ổ đĩa";
-"Retry" = "Thử lại";
-"Auto-mounts at login" = "Tự động gắn khi đăng nhập";
-"Mount Now" = "Gắn ngay";
-"Edit" = "Chỉnh sửa";
-"Delete" = "Xóa";
-
-"Accessibility Permission Required" = "Cần quyền Trợ năng";
-
-"Add Share" = "Thêm chia sẻ";
-
-"Optional (Defaults to share name)" = "Tùy chọn (Mặc định: tên chia sẻ)";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "Tùy chọn (Khách)";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ đã sử dụng / %@ (%@ còn trống)";
+"Preview: %@" = "Xem trước: %@";

--- a/MountMate/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 // MARK: - Action Buttons & Tooltips
 //=============================================
 
-"Expand All" = "展开全部";
-"Collapse All" = "折叠全部";
+"Expand All" = "全部展开";
+"Collapse All" = "全部折叠";
 "Unmount All" = "卸载所有卷宗";
 "Settings" = "设置";
 "Refresh Drives" = "刷新磁盘";
@@ -32,6 +32,8 @@
 
 "Unknown" = "未知";
 "Unmounted" = "已卸载";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "磁盘映像";
 
 
 // MARK: - Context Menus
@@ -47,20 +49,36 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "MountMate 设置";
-
 // Tabs
 "General" = "通用";
 "Management" = "管理";
+"Network Shares" = "网络共享";
 
-// General Tab
+// Display Section
+"Display" = "显示";
 "Show Count in Menu Bar" = "在菜单栏显示数量";
 "Show Internal Disks" = "显示内置磁盘";
+"Show Only Volumes" = "仅显示卷宗";
+
+// Behavior Section
+"Behavior" = "行为";
 "Start MountMate at Login" = "登录时启动 MountMate";
 "Block USB Auto-Mount" = "阻止 USB 自动挂载";
 "Unmount All Disks on Sleep" = "进入睡眠时卸载所有磁盘";
-"Language" = "语言";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "快捷键与语言";
 "Enable Keyboard Shortcuts" = "启用键盘快捷键";
+"Unmount All Volumes" = "卸载所有卷宗";
+"Mount All Volumes" = "挂载所有卷宗";
+"Language" = "语言";
+"English" = "英语";
+"Français" = "法语";
+"Українська" = "乌克兰语";
+"Русский" = "俄语";
+"Tiếng Việt" = "越南语";
+"中文（简体）" = "中文（简体）";
+"中文（繁体）" = "中文（繁体）";
 
 // About & Updates Section
 "About & Updates" = "关于与更新";
@@ -74,8 +92,8 @@
 "No Ignored Volumes" = "暂无忽略的卷宗";
 "Right-click a volume to ignore it. Useful for system partitions like 'EFI' that you don't need to manage." = "右键点击卷宗可将其忽略。对于无需管理的系统分区（如“EFI”）很有用。";
 "Protected Volumes" = "受保护卷宗";
-"No protected volumes" = "暂无受保护卷宗";
-"Right-click a volume to protect it from 'Unmount All' and system sleep actions." = "右键点击卷宗可将其设置为保护状态，防止被“卸载所有”或系统睡眠时卸载。";
+"No Protected Volumes" = "暂无受保护卷宗";
+"Right-click a volume to protect it from 'Unmount All' and sleep actions." = "右键点击卷宗可将其设置为保护状态，防止被“卸载所有”或系统睡眠时卸载。";
 
 "Don't Auto-Mount This Volume" = "禁止自动挂载此卷宗";
 "Blocked from Auto-Mounting" = "已被阻止自动挂载";
@@ -93,6 +111,9 @@
 "Unmount Failed" = "卸载失败";
 "“%@” is locked" = "“%@” 已被锁定";
 "Full Disk Access Recommended" = "建议授予完全磁盘访问权限";
+"Action Failed" = "操作失败";
+"Accessibility Permission Required" = "需要辅助功能权限";
+"Restart Required" = "需要重新启动";
 
 // Buttons
 "OK" = "好";
@@ -100,14 +121,21 @@
 "Cancel" = "取消";
 "Open System Settings" = "打开系统设置";
 "Later" = "稍后";
+"Retry" = "重试";
+"Try Again" = "重试";
+"Force Eject" = "强制推出";
+"Force Unmount" = "强制卸载";
+"Remember password in Keychain" = "在钥匙串中记住密码";
+"Restart Now" = "立即重新启动";
+"MountMate" = "MountMate";
+"Details" = "详细信息";
 
 // Verbs for error messages
 "unmount" = "卸载";
 "eject" = "推出";
 "mount" = "挂载";
 
-// Error message formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\n请在“系统设置 > 隐私与安全性”中为 MountMate 授予“完全磁盘访问权限”。";
+// Error Messages & Formats
 "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "“EFI” 分区是系统的特殊分区，无法直接挂载，这是正常现象。";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "由于其中的某个卷宗正在使用，无法推出“%@”。";
 "Failed to %@ “%@” because it is currently in use by another application." = "由于“%2$@”正被其他应用使用，无法执行 %1$@ 操作。";
@@ -116,55 +144,71 @@
 "Enter the password to unlock “%@”" = "请输入密码以解锁“%@”";
 "Password" = "密码";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "为确保 MountMate 能检测到所有类型的磁盘并避免错误，请授予“完全磁盘访问权限”。\n\n点击“打开系统设置”前往相关面板。";
+"MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate 无法获取磁盘信息。系统可能正忙、磁盘可能无响应，或权限可能不正确。";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "无法读取存储详情。请在“系统设置 > 隐私与安全性”中为 MountMate 授予“完全磁盘访问权限”或“文件和文件夹”权限。";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "无法保存“%@”的设置，因为它没有唯一标识符 (UUID)。";
 
+// Disk usage format
+"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";
 
-// MARK: - App Lifecycle
-//=============================================
-
+// App Lifecycle
 "Loading Disks..." = "正在加载磁盘...";
-"Restart Required" = "需要重新启动";
 "Please restart MountMate for the language change to take effect." = "请重新启动 MountMate 以使语言更改生效。";
-"Restart Now" = "立即重新启动";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用键盘快捷键，请在系统设置 → 隐私与安全 → 辅助功能 中授予 MountMate 辅助功能访问权限。";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "网络共享";
+
 "Add Share" = "添加共享";
 "Add Network Share" = "添加网络共享";
 "Edit Network Share" = "编辑网络共享";
-"Server Address" = "服务器地址";
-"Share Name/Path" = "共享名称/路径";
-"Username" = "用户名";
-"Password" = "密码";
-"Custom Mount Point" = "自定义挂载点";
-"Mount at Login" = "登录时挂载";
 "MountMate can automatically mount these SMB shares at login." = "MountMate 可以在登录时自动挂载这些 SMB 共享。";
 "No Network Shares Configured" = "未配置网络共享";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "在此添加您的 SMB 或 NAS 网络共享，以便自动或按需挂载。";
+"Saved Network Shares" = "已保存的网络共享";
+"Manually Connected Shares" = "手动连接的共享";
+"Eject All Manually Connected Shares" = "推出所有手动连接的共享";
+"Auto-mount" = "自动挂载";
+"Auto-mounts at login" = "登录时自动挂载";
+"Mount Share" = "挂载共享";
+"Unmount Share" = "卸载共享";
+"Edit Share" = "编辑共享";
+"Delete Share" = "删除共享";
+"Remove" = "移除";
 "Mounted" = "已挂载";
 "Not Mounted" = "未挂载";
 "Display Name" = "显示名称";
 "Connection" = "连接";
 "Credentials" = "凭证";
 "Options" = "选项";
+"Server Address" = "服务器地址";
+"Share Name/Path" = "共享名称/路径";
+"Username" = "用户名";
+"Custom Mount Point" = "自定义挂载点";
+"Mount at Login" = "登录时挂载";
 "Leave empty to use default location" = "留空以使用默认位置";
-"Preview: %@" = "预览: %@";
+"Optional (Defaults to share name)" = "可选（默认使用共享名）";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "可选（访客）";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "自定义挂载点…";
 "Use Custom Mount Point" = "使用自定义挂载点";
 "Folder Path" = "文件夹路径";
 "Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
 "Choose Folder" = "选择…";
 "Choose" = "选择";
-"Reset" = "重置";
+"Choose..." = "选择…";
+"Select custom mount directory" = "选择挂载文件夹";
 "Default Path" = "默认路径";
 "Save" = "保存";
 "Create" = "创建";
 "Use Folder" = "使用文件夹";
-"Custom Mount Point Help" = "关闭此选项可使用 macOS 标准挂载位置。";
-"Custom Mount Point Empty Means Default" = "留空即可使用 macOS 标准挂载位置。";
 "Custom Mount Point System Helper" = "留空即可使用 macOS 标准挂载位置。保存时会更新系统挂载规则，并且可能会要求您输入一次管理员密码。";
 "Custom Mount Point Summary" = "自定义: %@";
 "Create Folder Title" = "创建文件夹？";
@@ -176,8 +220,6 @@
 "Custom Mount Point Cannot Be Root" = "自定义挂载点不能是根目录。";
 "Custom Mount Point In Use" = "该文件夹已被已挂载的卷“%@”使用。";
 "Custom Mount Point Must Be Folder" = "自定义挂载点必须是文件夹。";
-"Custom Mount Point Prepare Fallback" = "MountMate 无法准备自定义挂载点。";
-"Custom Mount Point Prepare Error" = "MountMate 无法准备自定义挂载点。\n\n详细信息：\n%@";
 "Custom Mount Point Inspect Error" = "MountMate 无法检查此文件夹。\n\n详细信息：\n%@";
 "Custom Mount Point Create Error" = "MountMate 无法创建此文件夹。\n\n详细信息：\n%@";
 "Custom Mount Point Requires UUID" = "此卷没有稳定的 UUID，因此 MountMate 无法为其添加系统挂载规则。";
@@ -185,54 +227,10 @@
 "Custom Mount Point System Conflict" = "此卷已经有一个不受 MountMate 管理的 /etc/fstab 条目。";
 "Custom Mount Point System Error" = "MountMate 无法更新系统挂载规则。";
 "Custom Mount Point System Save Error" = "MountMate 无法更新系统挂载规则。\n\n详细信息：\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "强制推出";
-"The disk is in use. Do you want to force eject it?" = "磁盘正在使用中。您要强制推出吗？";
-"This may result in data loss." = "这可能会导致数据丢失。";
-"Remember password in Keychain" = "在钥匙串中记住密码";
 
-// 新增在 SwiftUI 视图中发现的字符串
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - 卸载所有卷";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - 挂载所有卷";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁体）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用键盘快捷键，请在系统设置 → 隐私与安全 → 辅助功能 中授予 MountMate 辅助功能访问权限。";
-
-"Volume: %@" = "卷： %@";
-"Disk: %@" = "磁盘： %@";
-"APFS Container • %@" = "APFS 容器 • %@";
-
-"Settings" = "设置";
-"Refresh Drives" = "刷新磁盘";
-"Retry" = "重试";
-"Auto-mounts at login" = "登录时自动挂载";
-"Mount Now" = "立即挂载";
-"Edit" = "编辑";
-"Delete" = "删除";
-
-"Accessibility Permission Required" = "需要辅助功能权限";
-
-"Add Share" = "添加共享";
-
-"Optional (Defaults to share name)" = "可选（默认使用共享名）";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "可选（访客）";
-
-// 剩余 UI 字符串
-"MountMate" = "MountMate";
-"Expand All" = "全部展开";
-"Collapse All" = "全部折叠";
-"Try Again" = "重试";
-"Action Failed" = "操作失败";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";
+"Preview: %@" = "预览: %@";

--- a/MountMate/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MountMate/Resources/zh-Hant.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 // MARK: - Action Buttons & Tooltips
 //=============================================
 
-"Expand All" = "展開全部";
-"Collapse All" = "折疊全部";
+"Expand All" = "全部展開";
+"Collapse All" = "全部摺疊";
 "Unmount All" = "卸載所有磁碟卷";
 "Settings" = "設定";
 "Refresh Drives" = "重新整理磁碟";
@@ -32,6 +32,8 @@
 
 "Unknown" = "未知";
 "Unmounted" = "已卸載";
+"Apple RAID" = "Apple RAID";
+"Disk Image" = "磁碟映像";
 
 
 // MARK: - Context Menus
@@ -47,20 +49,36 @@
 // MARK: - Settings View
 //=============================================
 
-"MountMate Settings" = "MountMate 設定";
-
 // Tabs
 "General" = "一般";
 "Management" = "管理";
+"Network Shares" = "網路共享";
 
-// General Tab
-"Enable Keyboard Shortcuts" = "啟用鍵盤快捷鍵";
+// Display Section
+"Display" = "顯示";
 "Show Count in Menu Bar" = "在選單列顯示數量";
 "Show Internal Disks" = "顯示內建磁碟";
+"Show Only Volumes" = "僅顯示磁碟卷";
+
+// Behavior Section
+"Behavior" = "行為";
 "Start MountMate at Login" = "登入時啟動 MountMate";
 "Block USB Auto-Mount" = "阻止 USB 自動掛載";
 "Unmount All Disks on Sleep" = "進入睡眠模式時卸載所有磁碟";
+
+// Shortcuts & Language Section
+"Shortcuts & Language" = "快速鍵與語言";
+"Enable Keyboard Shortcuts" = "啟用鍵盤快捷鍵";
+"Unmount All Volumes" = "卸載所有磁碟卷";
+"Mount All Volumes" = "掛載所有磁碟卷";
 "Language" = "語言";
+"English" = "英語";
+"Français" = "法語";
+"Українська" = "烏克蘭語";
+"Русский" = "俄語";
+"Tiếng Việt" = "越南語";
+"中文（简体）" = "中文（簡體）";
+"中文（繁体）" = "中文（繁體）";
 
 // About & Updates Section
 "About & Updates" = "關於與更新";
@@ -72,10 +90,10 @@
 // Management Tab
 "Ignored Volumes" = "已忽略的磁碟卷";
 "No Ignored Volumes" = "目前沒有被忽略的磁碟卷";
-"Right-click a volume to ignore it. Useful for system partitions like 'EFI' that you don't need to manage." = "在磁碟卷上按右鍵可將其忽略。對於无需管理的系統分割區（如「EFI」）很有用。";
+"Right-click a volume to ignore it. Useful for system partitions like 'EFI' that you don't need to manage." = "在磁碟卷上按右鍵可將其忽略。對於無需管理的系統分割區（如「EFI」）很有用。";
 "Protected Volumes" = "受保護的磁碟卷";
-"No protected volumes" = "目前沒有受保護的磁碟卷";
-"Right-click a volume to protect it from 'Unmount All' and system sleep actions." = "在磁碟卷上按右鍵可設定保護，以防在「卸載所有」或系統睡眠時被卸載。";
+"No Protected Volumes" = "目前沒有受保護的磁碟卷";
+"Right-click a volume to protect it from 'Unmount All' and sleep actions." = "在磁碟卷上按右鍵可設定保護，以防在「卸載所有」或系統睡眠時被卸載。";
 
 "Don't Auto-Mount This Volume" = "禁止自動掛載此磁碟卷";
 "Blocked from Auto-Mounting" = "已被禁止自動掛載";
@@ -93,6 +111,9 @@
 "Unmount Failed" = "卸載失敗";
 "“%@” is locked" = "「%@」已被鎖定";
 "Full Disk Access Recommended" = "建議授予完整磁碟存取權限";
+"Action Failed" = "操作失敗";
+"Accessibility Permission Required" = "需要輔助使用權限";
+"Restart Required" = "需要重新啟動";
 
 // Buttons
 "OK" = "好";
@@ -100,14 +121,21 @@
 "Cancel" = "取消";
 "Open System Settings" = "開啟系統設定";
 "Later" = "稍後";
+"Retry" = "重試";
+"Try Again" = "重試";
+"Force Eject" = "強制退出";
+"Force Unmount" = "強制卸載";
+"Remember password in Keychain" = "在鑰匙圈中記住密碼";
+"Restart Now" = "立即重新啟動";
+"MountMate" = "MountMate";
+"Details" = "詳細資料";
 
 // Verbs for error messages
 "unmount" = "卸載";
 "eject" = "推出";
 "mount" = "掛載";
 
-// Error message formats
-"\n\nPlease grant MountMate 'Full Disk Access' in System Settings > Privacy & Security." = "\n\n請在「系統設定 > 隱私與安全性」中為 MountMate 授予「完整磁碟存取權限」。";
+// Error Messages & Formats
 "The “EFI” partition cannot be mounted directly. This is a special system partition and this behavior is normal." = "「EFI」分割區為系統特殊分割區，無法直接掛載，這是正常現象。";
 "Failed to eject “%@” because one of its volumes is busy or in use." = "由於其中一個磁碟卷正在使用中，無法推出「%@」。";
 "Failed to %@ “%@” because it is currently in use by another application." = "由於「%2$@」目前正被其他應用程式使用，無法執行 %1$@ 操作。";
@@ -116,55 +144,71 @@
 "Enter the password to unlock “%@”" = "請輸入密碼以解鎖「%@」";
 "Password" = "密碼";
 "To ensure MountMate can see all disk types and prevent errors, please grant Full Disk Access.\n\nClick 'Open System Settings' to be taken to the correct panel." = "為確保 MountMate 能偵測所有磁碟類型並避免錯誤，請授予「完整磁碟存取權限」。\n\n點擊「開啟系統設定」以前往相關頁面。";
+"MountMate could not get disk information. The system may be busy, a disk may be unresponsive, or permissions may be incorrect." = "MountMate 無法取得磁碟資訊。系統可能忙碌、磁碟可能無回應，或權限可能不正確。";
+"Could not read storage details. Please grant MountMate 'Full Disk Access' or 'Files and Folders' permissions in System Settings > Privacy & Security." = "無法讀取儲存空間詳情。請在「系統設定 > 隱私與安全性」中為 MountMate 授予「完整磁碟存取權限」或「檔案與資料夾」權限。";
+"Could not save settings for “%@” because it does not have a unique identifier (UUID)." = "無法儲存“%@”的設定，因為它沒有唯一識別碼 (UUID)。";
 
+// Disk usage format
+"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";
 
-// MARK: - App Lifecycle
-//=============================================
-
+// App Lifecycle
 "Loading Disks..." = "正在載入磁碟...";
-"Restart Required" = "需要重新啟動";
 "Please restart MountMate for the language change to take effect." = "請重新啟動 MountMate 以使語言變更生效。";
-"Restart Now" = "立即重新啟動";
+"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用鍵盤快速鍵，請在系統設定 → 隱私與安全性 → 輔助使用 中為 MountMate 開啟輔助使用權限。";
+
 
 // MARK: - Network Shares
 //=============================================
-"Network Shares" = "網路共享";
-"Add Share" = "新增共享";
+
+"Add Share" = "新增共用";
 "Add Network Share" = "新增網路共享";
 "Edit Network Share" = "編輯網路共享";
-"Server Address" = "伺服器位址";
-"Share Name/Path" = "共享名稱/路徑";
-"Username" = "使用者名稱";
-"Password" = "密碼";
-"Custom Mount Point" = "自訂掛載點";
-"Mount at Login" = "登入時掛載";
 "MountMate can automatically mount these SMB shares at login." = "MountMate 可以在登入時自動掛載這些 SMB 共享。";
 "No Network Shares Configured" = "未設定網路共享";
+"Add your SMB or NAS network shares here to mount them automatically or on demand." = "在此新增您的 SMB 或 NAS 網路共享，以便自動或按需掛載。";
+"Saved Network Shares" = "已儲存的網路共享";
+"Manually Connected Shares" = "手動連線的共享";
+"Eject All Manually Connected Shares" = "推出所有手動連線的共享";
+"Auto-mount" = "自動掛載";
+"Auto-mounts at login" = "登入時自動掛載";
+"Mount Share" = "掛載共享";
+"Unmount Share" = "卸載共享";
+"Edit Share" = "編輯共享";
+"Delete Share" = "刪除共享";
+"Remove" = "移除";
 "Mounted" = "已掛載";
 "Not Mounted" = "未掛載";
 "Display Name" = "顯示名稱";
 "Connection" = "連線";
 "Credentials" = "憑證";
 "Options" = "選項";
+"Server Address" = "伺服器位址";
+"Share Name/Path" = "共享名稱/路徑";
+"Username" = "使用者名稱";
+"Custom Mount Point" = "自訂掛載點";
+"Mount at Login" = "登入時掛載";
 "Leave empty to use default location" = "留空以使用預設位置";
-"Preview: %@" = "預覽: %@";
+"Optional (Defaults to share name)" = "選填（預設為共用名稱）";
+"192.168.1.100" = "192.168.1.100";
+"public" = "public";
+"Optional (Guest)" = "選填（訪客）";
 
 
 // MARK: - Custom Mount Point
 //=============================================
+
 "Custom Mount Point Menu" = "自訂掛載點…";
 "Use Custom Mount Point" = "使用自訂掛載點";
 "Folder Path" = "資料夾路徑";
 "Custom Mount Point Path Prompt" = "/Volumes/MyDrive";
 "Choose Folder" = "選擇…";
 "Choose" = "選擇";
-"Reset" = "重設";
+"Choose..." = "選擇…";
+"Select custom mount directory" = "選擇掛載資料夾";
 "Default Path" = "預設路徑";
 "Save" = "儲存";
 "Create" = "建立";
 "Use Folder" = "使用資料夾";
-"Custom Mount Point Help" = "關閉此選項即可使用 macOS 標準掛載位置。";
-"Custom Mount Point Empty Means Default" = "留空即可使用 macOS 標準掛載位置。";
 "Custom Mount Point System Helper" = "留空即可使用 macOS 標準掛載位置。儲存時會更新系統掛載規則，並且可能會要求您輸入一次管理員密碼。";
 "Custom Mount Point Summary" = "自訂: %@";
 "Create Folder Title" = "建立資料夾？";
@@ -176,8 +220,6 @@
 "Custom Mount Point Cannot Be Root" = "自訂掛載點不能是根目錄。";
 "Custom Mount Point In Use" = "此資料夾已被已掛載的磁碟卷「%@」使用。";
 "Custom Mount Point Must Be Folder" = "自訂掛載點必須是資料夾。";
-"Custom Mount Point Prepare Fallback" = "MountMate 無法準備自訂掛載點。";
-"Custom Mount Point Prepare Error" = "MountMate 無法準備自訂掛載點。\n\n詳細資料：\n%@";
 "Custom Mount Point Inspect Error" = "MountMate 無法檢查此資料夾。\n\n詳細資料：\n%@";
 "Custom Mount Point Create Error" = "MountMate 無法建立此資料夾。\n\n詳細資料：\n%@";
 "Custom Mount Point Requires UUID" = "此磁碟卷沒有穩定的 UUID，因此 MountMate 無法為它新增系統掛載規則。";
@@ -185,54 +227,10 @@
 "Custom Mount Point System Conflict" = "此磁碟卷已經有一個不是由 MountMate 管理的 /etc/fstab 項目。";
 "Custom Mount Point System Error" = "MountMate 無法更新系統掛載規則。";
 "Custom Mount Point System Save Error" = "MountMate 無法更新系統掛載規則。\n\n詳細資料：\n%@";
+"~/mountmate/MyShare" = "~/mountmate/MyShare";
 
-// MARK: - Force Eject
+
+// MARK: - Connection String Preview
 //=============================================
-"Force Eject" = "強制退出";
-"The disk is in use. Do you want to force eject it?" = "磁碟正在使用中。您要強制退出嗎？";
-"This may result in data loss." = "這可能會導致資料遺失。";
-"Remember password in Keychain" = "在鑰匙圈中記住密碼";
 
-// 剩餘字串
-"MountMate" = "MountMate";
-"Expand All" = "全部展開";
-"Collapse All" = "全部摺疊";
-"Try Again" = "重試";
-"Action Failed" = "操作失敗";
-
-// 新增在 SwiftUI 視圖中發現的字串
-"⌘⇧U - Unmount All Volumes" = "⌘⇧U - 卸載所有卷";
-"⌘⇧M - Mount All Volumes" = "⌘⇧M - 掛載所有卷";
-
-"English" = "English";
-"Français" = "Français";
-"Українська" = "Українська";
-"Tiếng Việt" = "Tiếng Việt";
-"中文（简体）" = "中文（简体）";
-"中文（繁体）" = "中文（繁體）";
-
-"To use keyboard shortcuts, please grant MountMate Accessibility access in System Settings → Privacy & Security → Accessibility." = "要使用鍵盤快速鍵，請在系統設定 → 隱私與安全性 → 輔助使用 中為 MountMate 開啟輔助使用權限。";
-
-"Volume: %@" = "卷： %@";
-"Disk: %@" = "磁碟： %@";
-"APFS Container • %@" = "APFS 容器 • %@";
-
-"Settings" = "設定";
-"Refresh Drives" = "重新整理磁碟";
-"Retry" = "重試";
-"Auto-mounts at login" = "登入時自動掛載";
-"Mount Now" = "立即掛載";
-"Edit" = "編輯";
-"Delete" = "刪除";
-
-"Accessibility Permission Required" = "需要輔助使用權限";
-
-"Add Share" = "新增共用";
-
-"Optional (Defaults to share name)" = "選填（預設為共用名稱）";
-"192.168.1.100" = "192.168.1.100";
-"public" = "public";
-"Optional (Guest)" = "選填（訪客）";
-
-// Disk usage format
-"DiskUsageUsedFree" = "%@ 已用 / %@ (%@ 可用)";
+"Preview: %@" = "預覽: %@";

--- a/MountMate/Views/Main/ManualSharesSectionHeader.swift
+++ b/MountMate/Views/Main/ManualSharesSectionHeader.swift
@@ -26,7 +26,7 @@ struct ManualSharesSectionHeader: View {
     networkManager.unmountAllManuallyConnectedShares { failures in
       guard !failures.isEmpty else { return }
       DriveManager.shared.userActionError = AppAlert(
-        title: "Eject Failed",
+        title: NSLocalizedString("Eject Failed", comment: "Alert title"),
         message: "Could not eject: \(failures.joined(separator: ", "))",
         kind: .basic)
     }

--- a/MountMate/Views/Main/NetworkShareMainRow.swift
+++ b/MountMate/Views/Main/NetworkShareMainRow.swift
@@ -36,7 +36,7 @@ struct NetworkShareMainRow: View {
               .bold()
               .foregroundStyle(isMounted ? .primary : .secondary)
 
-            Text(isMounted ? "Mounted" : "Not Mounted")
+            Text(isMounted ? NSLocalizedString("Mounted", comment: "Status") : NSLocalizedString("Not Mounted", comment: "Status"))
               .font(.caption)
               .foregroundStyle(.secondary)
           }
@@ -57,7 +57,7 @@ struct NetworkShareMainRow: View {
               isWorking = false
               if !success, let error = error {
                 DriveManager.shared.userActionError = AppAlert(
-                  title: "Unmount Failed", message: error, kind: .basic)
+                  title: NSLocalizedString("Unmount Failed", comment: "Alert title"), message: error, kind: .basic)
               }
             }
           } else {
@@ -65,13 +65,13 @@ struct NetworkShareMainRow: View {
               isWorking = false
               if !success, let error = error {
                 DriveManager.shared.userActionError = AppAlert(
-                  title: "Mount Failed", message: error, kind: .basic)
+                  title: NSLocalizedString("Mount Failed", comment: "Alert title"), message: error, kind: .basic)
               }
             }
           }
         }) {
           Label(
-            isMounted ? "Eject" : "Mount",
+            isMounted ? NSLocalizedString("Eject", comment: "Action") : NSLocalizedString("Mount", comment: "Action"),
             systemImage: isMounted ? "eject.fill" : "play.fill"
           )
           .font(.caption)
@@ -87,7 +87,7 @@ struct NetworkShareMainRow: View {
             ProgressView().controlSize(.small)
           }
         }
-        .help(isMounted ? "Eject" : "Mount")
+        .help(isMounted ? NSLocalizedString("Eject", comment: "Tooltip") : NSLocalizedString("Mount", comment: "Tooltip"))
         .padding(.leading, 8)
       }
       .padding(.vertical, 4)

--- a/MountMate/Views/Settings/EditNetworkShareSheet.swift
+++ b/MountMate/Views/Settings/EditNetworkShareSheet.swift
@@ -147,8 +147,8 @@ struct EditNetworkShareSheet: View {
     panel.canChooseFiles = false
     panel.canChooseDirectories = true
     panel.allowsMultipleSelection = false
-    panel.prompt = "Choose"
-    panel.message = "Select custom mount directory"
+    panel.prompt = NSLocalizedString("Choose", comment: "Choose button")
+    panel.message = NSLocalizedString("Select custom mount directory", comment: "Open panel message")
     if panel.runModal() == .OK, let url = panel.url {
       customMountPoint = url.path
     }

--- a/MountMate/Views/Settings/NetworkSharesSettingsView.swift
+++ b/MountMate/Views/Settings/NetworkSharesSettingsView.swift
@@ -29,7 +29,7 @@ struct NetworkSharesSettingsView: View {
             NetworkShareRow(
               share: share, onEdit: { editingShare = share },
               onError: { error in
-                errorAlert = AppAlert(title: "Mount Failed", message: error, kind: .basic)
+                errorAlert = AppAlert(title: NSLocalizedString("Mount Failed", comment: "Alert title"), message: error, kind: .basic)
               })
           }
         }


### PR DESCRIPTION
- ru/uk: fix typos in translations
- fr: translate previously untranslated error strings
- zh-Hant: replace simplified glyphs with traditional
- vi: unify "Unmount All" / "Eject" wording
- add missing keys used in code (Apple RAID, Disk Image, Choose..., Select custom mount directory, Details)
- localize language names in the settings Picker
- wrap EditNetworkShareSheet panel.prompt/message in NSLocalizedString
- replace hardcoded "Details:" in DriveManager errors with NSLocalizedString

<img width="632" height="740" alt="Снимок экрана — 2026-08-13 в 10 41 46" src="https://github.com/user-attachments/assets/30e0f125-da94-43e2-85ea-e7f7097e8deb" />
<img width="654" height="742" alt="Снимок экрана — 2026-08-13 в 10 42 06" src="https://github.com/user-attachments/assets/02f237de-0644-485e-bc5d-eede39742c3c" />
